### PR TITLE
feat: support minimum height of month view

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -482,3 +482,16 @@ var cal = new Calendar('#calendar', {
     }
 });
 ```
+
+### Fit the calendar size for parent element
+TOAST UI Calendar's default height is 600px. If you want this calendar to fit to parent element, write container element's css like this. 
+
+```css
+#calendar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 5px;
+    top: 64px;
+}
+```

--- a/src/css/month.styl
+++ b/src/css/month.styl
@@ -1,5 +1,6 @@
 .{css-prefix}month
     height: 100%
+    min-height: 600px
 
 +prefix-classes(month)
     .dayname

--- a/src/css/week/layout.styl
+++ b/src/css/week/layout.styl
@@ -3,6 +3,7 @@
     height: inherit
     display: inline-block
     font-size: 10px
+    min-height: 600px
 
     .{css-prefix}today
         background: none


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

If no css height of container element, the month view and week time grid have 0px height. I add minimum height in this case. The Calendar's default height is set to 600px.

And I add the related guide.

### Fit the calendar size for parent element
TOAST UI Calendar's default height is 600px. If you want this calendar to fit to parent element, write container element's css like this. 

```css
#calendar {
    position: absolute;
    left: 0;
    right: 0;
    bottom: 5px;
    top: 64px;
}
```


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
