### PR TITLE
Fix : hide resize icon with isReadOnly=true option (fix #359)

### DIFF
--- a/src/css/common.styl
+++ b/src/css/common.styl
@@ -44,9 +44,6 @@
 .{css-prefix}today
     background: rgba(218, 229, 249, .3)
 
-.{css-prefix}hide
-    display: none;
-
 // Drag handle
 .handle-x
     background-position: center center

--- a/src/css/common.styl
+++ b/src/css/common.styl
@@ -44,6 +44,9 @@
 .{css-prefix}today
     background: rgba(218, 229, 249, .3)
 
+.{css-prefix}hide
+    display: none;
+
 // Drag handle
 .handle-x
     background-position: center center

--- a/src/js/view/template/week/time.hbs
+++ b/src/js/view/template/week/time.hbs
@@ -53,7 +53,7 @@
                 {{/if}};">{{{comingDuration-tmpl model}}}</div>
             {{/if}}
             </div>
-            {{#unless croppedEnd}}<div class="{{CSS_PREFIX}}time-resize-handle handle-x{{#if model.isReadOnly}} {{CSS_PREFIX}}hide{{/if}}">&nbsp;</div>{{/unless}}
+            {{#unless (or croppedEnd model.isReadOnly)}}<div class="{{CSS_PREFIX}}time-resize-handle handle-x">&nbsp;</div>{{/unless}}
         </div>
         {{/if ~}}
         {{/each}}

--- a/src/js/view/template/week/time.hbs
+++ b/src/js/view/template/week/time.hbs
@@ -53,7 +53,7 @@
                 {{/if}};">{{{comingDuration-tmpl model}}}</div>
             {{/if}}
             </div>
-            {{#unless croppedEnd}}<div class="{{CSS_PREFIX}}time-resize-handle handle-x" style="margin-left: {{@root.styles.paddingLeft}};">&nbsp;</div>{{/unless}}
+            {{#unless croppedEnd}}<div class="{{CSS_PREFIX}}time-resize-handle handle-x{{#if model.isReadOnly}} {{CSS_PREFIX}}hide{{/if}}">&nbsp;</div>{{/unless}}
         </div>
         {{/if ~}}
         {{/each}}

--- a/src/js/view/template/week/time.hbs
+++ b/src/js/view/template/week/time.hbs
@@ -53,7 +53,7 @@
                 {{/if}};">{{{comingDuration-tmpl model}}}</div>
             {{/if}}
             </div>
-            {{#unless (or croppedEnd model.isReadOnly)}}<div class="{{CSS_PREFIX}}time-resize-handle handle-x">&nbsp;</div>{{/unless}}
+            {{#unless (or croppedEnd model.isReadOnly)}}<div class="{{CSS_PREFIX}}time-resize-handle handle-x" style="margin-left: {{@root.styles.paddingLeft}};">&nbsp;</div>{{/unless}}
         </div>
         {{/if ~}}
         {{/each}}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
When isReadOnly = true, it is impossible to move the schedule, and it is impossible to adjust the size.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
