### PR TITLE
fix: update type definitions to use ES6 module definitions #383

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,294 +1,289 @@
 // Type definitions for TOAST UI Calendar v1.12.4
 // TypeScript Version: 3.2.1
 
-declare namespace tuiCalendar {
-    type DateType = string | TZDate | Date;
-    type AfterRenderScheduleEventHandlerFunc = (eventObj: {schedule: ISchedule}) => void;
-    type BeforeCreateScheduleEventHandlerFunc = (schedule: ISchedule) => void;
-    type BeforeDeleteScheduleEventHandlerFunc = (eventObj: IEventScheduleObject) => void;
-    type BeforeUpdateScheduleEventHandlerFunc = (eventObj: IEventObject) => void;
-    type ClickDayNameEventHandlerFunc = (eventObj: IEventDateObject) => void;
-    type ClickMoreEventHandlerFunc = (eventObj: IEventMoreObject) => void;
-    type ClickScheduleEventHandlerFunc = (eventObj: IEventScheduleObject) => void;
-    type TimezonesCollapseEventFunc = (timezonesCollapsed: boolean) => void;
-    type EventHandlerType = AfterRenderScheduleEventHandlerFunc |
-        BeforeCreateScheduleEventHandlerFunc |
-        BeforeDeleteScheduleEventHandlerFunc |
-        BeforeUpdateScheduleEventHandlerFunc |
-        ClickDayNameEventHandlerFunc |
-        ClickMoreEventHandlerFunc |
-        ClickScheduleEventHandlerFunc |
-        TimezonesCollapseEventFunc;
-    type CustomEventType = 'afterRenderSchedule' | 'beforeCreateSchedule' |
-        'beforeDeleteSchedule' | 'beforeUpdateSchedule' | 'clickDayname' |
-        'clickMore' | 'clickSchedule' | 'clickTimezonesCollapseBtn';
+export type DateType = string | TZDate | Date;
+export type AfterRenderScheduleEventHandlerFunc = (eventObj: {schedule: ISchedule}) => void;
+export type BeforeCreateScheduleEventHandlerFunc = (schedule: ISchedule) => void;
+export type BeforeDeleteScheduleEventHandlerFunc = (eventObj: IEventScheduleObject) => void;
+export type BeforeUpdateScheduleEventHandlerFunc = (eventObj: IEventObject) => void;
+export type ClickDayNameEventHandlerFunc = (eventObj: IEventDateObject) => void;
+export type ClickMoreEventHandlerFunc = (eventObj: IEventMoreObject) => void;
+export type ClickScheduleEventHandlerFunc = (eventObj: IEventScheduleObject) => void;
+export type TimezonesCollapseEventFunc = (timezonesCollapsed: boolean) => void;
+export type EventHandlerType = AfterRenderScheduleEventHandlerFunc |
+    BeforeCreateScheduleEventHandlerFunc |
+    BeforeDeleteScheduleEventHandlerFunc |
+    BeforeUpdateScheduleEventHandlerFunc |
+    ClickDayNameEventHandlerFunc |
+    ClickMoreEventHandlerFunc |
+    ClickScheduleEventHandlerFunc |
+    TimezonesCollapseEventFunc;
+export type CustomEventType = 'afterRenderSchedule' | 'beforeCreateSchedule' |
+    'beforeDeleteSchedule' | 'beforeUpdateSchedule' | 'clickDayname' |
+    'clickMore' | 'clickSchedule' | 'clickTimezonesCollapseBtn';
 
-    interface IEventObject {
-        schedule: ISchedule;
-        end: TZDate;
-        start: TZDate;
-        calendar?: ICalendarInfo;
-        triggerEventName?: string;
-    }
-
-    interface IEventDateObject {
-        date: string;
-    }
-
-    interface IEventMoreObject {
-        date: TZDate;
-        target: Element;
-    }
-
-    interface IEventScheduleObject {
-        calendar: ICalendarInfo;
-        event: MouseEvent;
-        schedule: ISchedule;
-
-    }
-    interface IEvents {
-        'afterRenderSchedule'?: AfterRenderScheduleEventHandlerFunc;
-        'beforeCreateSchedule'?: BeforeCreateScheduleEventHandlerFunc;
-        'beforeDeleteSchedule'?: BeforeDeleteScheduleEventHandlerFunc;
-        'beforeUpdateSchedule'?: BeforeUpdateScheduleEventHandlerFunc;
-        'clickDayname'?: ClickDayNameEventHandlerFunc;
-        'clickMore'?: ClickMoreEventHandlerFunc;
-        'clickSchedule'?: ClickScheduleEventHandlerFunc;
-        'clickTimezonesCollapseBtn'?: TimezonesCollapseEventFunc;
-    }
-
-    class TZDate {
-        public getTime(): number;
-        public toDate(): Date;
-        public toUTCString(): Date;
-    }
-
-    interface ICalendarColor {
-        color?: string;
-        bgColor?: string;
-        dragBgColor?: string;
-        borderColor?: string;
-    }
-
-    interface ITimeGridHourLabel {
-        hidden: boolean;
-        hour: number;
-        minutes: number;
-    }
-
-    interface ITimezoneHourMarker {
-        hourmarker: TZDate;
-        dateDifferenceSign: string;
-        dateDifference: number;
-    }
-
-    interface IGridDateModel {
-        date: string;
-        day: number;
-        hiddenSchedules: number;
-        isOtherMonth: boolean;
-        isToday: boolean;
-        month: number;
-        ymd: string;
-    }
-
-    interface IWeekDayNameInfo {
-        date: number;
-        day: number;
-        dayName: string;
-        isToday: boolean;
-        renderDate: string;
-    }
-
-    interface IMonthDayNameInfo {
-        day: number;
-        label: string;
-    }
-
-    interface ITemplateConfig {
-        milestoneTitle?: () => string;
-        milestone?: (schedule: ISchedule) => string;
-        taskTitle?: () => string;
-        task?: (schedule: ISchedule) => string;
-        alldayTitle?: () => string;
-        allday?: (schedule: ISchedule) => string;
-        time?: (schedule: ISchedule) => string;
-        goingDuration?: (schedule: ISchedule) => string;
-        comingDuration?: (schedule: ISchedule) => string;
-        monthMoreTitleDate?: (date: string, dayname: string) => string;
-        monthMoreClose?: () => string;
-        monthGridHeader?: (model: IGridDateModel) => string;
-        monthGridHeaderExceed?: (hiddenSchedules: number) => string;
-        monthGridFooter?: (model: IGridDateModel) => string;
-        monthGridFooterExceed?: (hiddenSchedules: number) => string;
-        monthDayname?: (model: IMonthDayNameInfo) => string;
-        weekDayname?: (model: IWeekDayNameInfo) => string;
-        weekGridFooterExceed?: (hiddenSchedules: number) => string;
-        dayGridTitle?: (viewName: string) => string;
-        schedule?: (schedule: ISchedule) => string;
-        collapseBtnTitle?: () => string;
-        timezoneDisplayLabel?: (timezoneOffset: number, displayLabel: string) => string;
-        timegridDisplayPrimayTime?: (time: ITimeGridHourLabel) => string;
-        timegridDisplayPrimaryTime?: (time: ITimeGridHourLabel) => string;
-        timegridDisplayTime?: (time: ITimeGridHourLabel) => string;
-        timegridCurrentTime?: (hourMarker: ITimezoneHourMarker) => string;
-        popupIsAllDay?: () => string;
-        popupStateFree?: () => string;
-        popupStateBusy?: () => string;
-        titlePlaceholder?: () => string;
-        locationPlaceholder?: () => string;
-        startDatePlaceholder?: () => string;
-        endDatePlaceholder?: () => string;
-        popupSave?: () => string;
-        popupUpdate?: () => string;
-        popupDetailDate?: (isAllDay: boolean, start: DateType, end: DateType) => string;
-        popupDetailLocation?: (schedule: ISchedule) => string;
-        popupDetailUser?: (schedule: ISchedule) => string;
-        popupDetailState?: (schedule: ISchedule) => string;
-        popupDetailRepeat?: (schedule: ISchedule) => string;
-        popupDetailBody?: (schedule: ISchedule) => string;
-        popupEdit?: () => string;
-        popupDelete?: () => string;
-    }
-
-    interface IWeekOptions {
-        startDayOfWeek?: number;
-        daynames?: string[];
-        narrowWeekend?: boolean;
-        workweek?: boolean;
-        showTimezoneCollapseButton?: boolean;
-        timezoneCollapsed?: boolean;
-        hourStart?: number;
-        hourEnd?: number;
-    }
-
-    interface IMonthOptions {
-        daynames?: string[];
-        startDayOfWeek?: number;
-        narrowWeekend?: boolean;
-        visibleWeeksCount?: number;
-        isAlways6Week?: boolean;
-        workweek?: boolean;
-        visibleScheduleCount?: number;
-        moreLayerSize?: {
-            width?: string | null;
-            height?: string | null;
-        };
-        grid?: {
-            header?: {
-                height?: number;
-            },
-            footer?: {
-                height?: number;
-            }
-        };
-        scheduleFilter?: (schedule: ISchedule) => boolean;
-    }
-
-    interface IRaw {
-        [propName: string]: string | number | boolean | object | null;
-    }
-
-    interface ISchedule {
-        id?: string;
-        calendarId?: string;
-        title?: string;
-        body?: string;
-        start?: DateType;
-        end?: DateType;
-        goingDuration?: number;
-        comingDuration?: number;
-        isAllDay?: boolean;
-        category?: string;
-        dueDateClass?: string;
-        location?: string;
-        attendees?: string[];
-        recurrenceRule?: string;
-        isPending?: boolean;
-        isFocused?: boolean;
-        isVisible?: boolean;
-        isReadOnly?: boolean;
-        isPrivate?: boolean;
-        color?: string;
-        bgColor?: string;
-        dragBgColor?: string;
-        borderColor?: string;
-        customStyle?: string;
-        raw?: any;
-        state?: string;
-    }
-
-    interface ITimezone {
-        timezoneOffset?: number;
-        displayLabel?: string;
-        tooltip?: string;
-    }
-
-    interface ICalendarInfo {
-        id: string;
-        name: string;
-        color?: string;
-        bgColor?: string;
-        dragBgColor?: string;
-        borderColor?: string;
-    }
-
-    interface IOptions {
-        defaultView?: string;
-        taskView?: boolean | string[];
-        scheduleView?: boolean | string[];
-        theme?: object;
-        template?: ITemplateConfig;
-        week?: IWeekOptions;
-        month?: IMonthOptions;
-        calendars?: Calendar[];
-        useCreationPopup?: boolean;
-        useDetailPopup?: boolean;
-        timezones?: ITimezone[];
-        disableDblClick?: boolean;
-        disableClick?: boolean;
-        isReadOnly?: boolean;
-        usageStatistics?: boolean;
-    }
-
-    class Calendar {
-        public static setTimezoneOffset(offset: number): void;
-        public static setTimezoneOffsetCallback(callback: (timestamp: number) => void): void;
-
-        constructor(container: Element | string, options?: IOptions);
-
-        public changeView(newViewName: string, force?: boolean): void;
-        public clear(immediately?: boolean): void;
-        public createSchedules(schedules: ISchedule[], silent?: boolean): void;
-        public deleteSchedule(scheduleId: string, calendarId: string, silent?: boolean): void;
-        public destroy(): void;
-        public getDate(): TZDate;
-        public getDateRangeEnd(): TZDate;
-        public getDateRangeStart(): TZDate;
-        public getElement(scheduleId: string, calendarId: string): Element;
-        public getOptions(): IOptions;
-        public getSchedule(scheduleId: string, calendarId: string): ISchedule;
-        public getViewName(): string;
-        public hideMoreView(): void;
-        public next(): void;
-        public openCreationPopup(schedule: ISchedule): void;
-        public prev(): void;
-        public render(immediately?: boolean): void;
-        public scrollToNow(): void;
-        public setCalendarColor(calendarId: string, option: ICalendarColor, silent?: boolean): void;
-        public setCalendars(calendars: ICalendarInfo[]): void;
-        public setDate(date: Date | string): void;
-        public setOptions(options: IOptions, silent?: boolean): void;
-        public setTheme(theme: object): string[];
-        public today(): void;
-        public toggleSchedules(calendarId: string, toHide: boolean, render?: boolean): void;
-        public toggleScheduleView(enabled: boolean): void;
-        public toggleTaskView(enabled: boolean): void;
-        public updateSchedule(scheduleId: string, calendarId: string, scheduleData: ISchedule, silent?: boolean): void;
-        public off(eventName?: string | object | EventHandlerType, handler?: EventHandlerType | string): void;
-        public on(event: CustomEventType | IEvents, handler?: EventHandlerType): void;
-    }
+export interface IEventObject {
+    schedule: ISchedule;
+    end: TZDate;
+    start: TZDate;
+    calendar?: ICalendarInfo;
+    triggerEventName?: string;
 }
-declare module 'tui-calendar' {
-    export default tuiCalendar.Calendar;
+
+export interface IEventDateObject {
+    date: string;
+}
+
+export interface IEventMoreObject {
+    date: TZDate;
+    target: Element;
+}
+
+export interface IEventScheduleObject {
+    calendar: ICalendarInfo;
+    event: MouseEvent;
+    schedule: ISchedule;
+
+}
+export interface IEvents {
+    'afterRenderSchedule'?: AfterRenderScheduleEventHandlerFunc;
+    'beforeCreateSchedule'?: BeforeCreateScheduleEventHandlerFunc;
+    'beforeDeleteSchedule'?: BeforeDeleteScheduleEventHandlerFunc;
+    'beforeUpdateSchedule'?: BeforeUpdateScheduleEventHandlerFunc;
+    'clickDayname'?: ClickDayNameEventHandlerFunc;
+    'clickMore'?: ClickMoreEventHandlerFunc;
+    'clickSchedule'?: ClickScheduleEventHandlerFunc;
+    'clickTimezonesCollapseBtn'?: TimezonesCollapseEventFunc;
+}
+
+interface TZDate {
+    getTime(): number;
+    toDate(): Date;
+    toUTCString(): Date;
+}
+
+export interface ICalendarColor {
+    color?: string;
+    bgColor?: string;
+    dragBgColor?: string;
+    borderColor?: string;
+}
+
+export interface ITimeGridHourLabel {
+    hidden: boolean;
+    hour: number;
+    minutes: number;
+}
+
+export interface ITimezoneHourMarker {
+    hourmarker: TZDate;
+    dateDifferenceSign: string;
+    dateDifference: number;
+}
+
+export interface IGridDateModel {
+    date: string;
+    day: number;
+    hiddenSchedules: number;
+    isOtherMonth: boolean;
+    isToday: boolean;
+    month: number;
+    ymd: string;
+}
+
+export interface IWeekDayNameInfo {
+    date: number;
+    day: number;
+    dayName: string;
+    isToday: boolean;
+    renderDate: string;
+}
+
+export interface IMonthDayNameInfo {
+    day: number;
+    label: string;
+}
+
+export interface ITemplateConfig {
+    milestoneTitle?: () => string;
+    milestone?: (schedule: ISchedule) => string;
+    taskTitle?: () => string;
+    task?: (schedule: ISchedule) => string;
+    alldayTitle?: () => string;
+    allday?: (schedule: ISchedule) => string;
+    time?: (schedule: ISchedule) => string;
+    goingDuration?: (schedule: ISchedule) => string;
+    comingDuration?: (schedule: ISchedule) => string;
+    monthMoreTitleDate?: (date: string, dayname: string) => string;
+    monthMoreClose?: () => string;
+    monthGridHeader?: (model: IGridDateModel) => string;
+    monthGridHeaderExceed?: (hiddenSchedules: number) => string;
+    monthGridFooter?: (model: IGridDateModel) => string;
+    monthGridFooterExceed?: (hiddenSchedules: number) => string;
+    monthDayname?: (model: IMonthDayNameInfo) => string;
+    weekDayname?: (model: IWeekDayNameInfo) => string;
+    weekGridFooterExceed?: (hiddenSchedules: number) => string;
+    dayGridTitle?: (viewName: string) => string;
+    schedule?: (schedule: ISchedule) => string;
+    collapseBtnTitle?: () => string;
+    timezoneDisplayLabel?: (timezoneOffset: number, displayLabel: string) => string;
+    timegridDisplayPrimayTime?: (time: ITimeGridHourLabel) => string;
+    timegridDisplayPrimaryTime?: (time: ITimeGridHourLabel) => string;
+    timegridDisplayTime?: (time: ITimeGridHourLabel) => string;
+    timegridCurrentTime?: (hourMarker: ITimezoneHourMarker) => string;
+    popupIsAllDay?: () => string;
+    popupStateFree?: () => string;
+    popupStateBusy?: () => string;
+    titlePlaceholder?: () => string;
+    locationPlaceholder?: () => string;
+    startDatePlaceholder?: () => string;
+    endDatePlaceholder?: () => string;
+    popupSave?: () => string;
+    popupUpdate?: () => string;
+    popupDetailDate?: (isAllDay: boolean, start: DateType, end: DateType) => string;
+    popupDetailLocation?: (schedule: ISchedule) => string;
+    popupDetailUser?: (schedule: ISchedule) => string;
+    popupDetailState?: (schedule: ISchedule) => string;
+    popupDetailRepeat?: (schedule: ISchedule) => string;
+    popupDetailBody?: (schedule: ISchedule) => string;
+    popupEdit?: () => string;
+    popupDelete?: () => string;
+}
+
+export interface IWeekOptions {
+    startDayOfWeek?: number;
+    daynames?: string[];
+    narrowWeekend?: boolean;
+    workweek?: boolean;
+    showTimezoneCollapseButton?: boolean;
+    timezoneCollapsed?: boolean;
+    hourStart?: number;
+    hourEnd?: number;
+}
+
+export interface IMonthOptions {
+    daynames?: string[];
+    startDayOfWeek?: number;
+    narrowWeekend?: boolean;
+    visibleWeeksCount?: number;
+    isAlways6Week?: boolean;
+    workweek?: boolean;
+    visibleScheduleCount?: number;
+    moreLayerSize?: {
+        width?: string | null;
+        height?: string | null;
+    };
+    grid?: {
+        header?: {
+            height?: number;
+        },
+        footer?: {
+            height?: number;
+        }
+    };
+    scheduleFilter?: (schedule: ISchedule) => boolean;
+}
+
+export interface IRaw {
+    [propName: string]: string | number | boolean | object | null;
+}
+
+export interface ISchedule {
+    id?: string;
+    calendarId?: string;
+    title?: string;
+    body?: string;
+    start?: DateType;
+    end?: DateType;
+    goingDuration?: number;
+    comingDuration?: number;
+    isAllDay?: boolean;
+    category?: string;
+    dueDateClass?: string;
+    location?: string;
+    attendees?: string[];
+    recurrenceRule?: string;
+    isPending?: boolean;
+    isFocused?: boolean;
+    isVisible?: boolean;
+    isReadOnly?: boolean;
+    isPrivate?: boolean;
+    color?: string;
+    bgColor?: string;
+    dragBgColor?: string;
+    borderColor?: string;
+    customStyle?: string;
+    raw?: any;
+    state?: string;
+}
+
+export interface ITimezone {
+    timezoneOffset?: number;
+    displayLabel?: string;
+    tooltip?: string;
+}
+
+export interface ICalendarInfo {
+    id: string;
+    name: string;
+    color?: string;
+    bgColor?: string;
+    dragBgColor?: string;
+    borderColor?: string;
+}
+
+export interface IOptions {
+    defaultView?: string;
+    taskView?: boolean | string[];
+    scheduleView?: boolean | string[];
+    theme?: object;
+    template?: ITemplateConfig;
+    week?: IWeekOptions;
+    month?: IMonthOptions;
+    calendars?: Calendar[];
+    useCreationPopup?: boolean;
+    useDetailPopup?: boolean;
+    timezones?: ITimezone[];
+    disableDblClick?: boolean;
+    disableClick?: boolean;
+    isReadOnly?: boolean;
+    usageStatistics?: boolean;
+}
+
+export default class Calendar {
+    public static setTimezoneOffset(offset: number): void;
+    public static setTimezoneOffsetCallback(callback: (timestamp: number) => void): void;
+
+    constructor(container: Element | string, options?: IOptions);
+
+    public changeView(newViewName: string, force?: boolean): void;
+    public clear(immediately?: boolean): void;
+    public createSchedules(schedules: ISchedule[], silent?: boolean): void;
+    public deleteSchedule(scheduleId: string, calendarId: string, silent?: boolean): void;
+    public destroy(): void;
+    public getDate(): TZDate;
+    public getDateRangeEnd(): TZDate;
+    public getDateRangeStart(): TZDate;
+    public getElement(scheduleId: string, calendarId: string): Element;
+    public getOptions(): IOptions;
+    public getSchedule(scheduleId: string, calendarId: string): ISchedule;
+    public getViewName(): string;
+    public hideMoreView(): void;
+    public next(): void;
+    public openCreationPopup(schedule: ISchedule): void;
+    public prev(): void;
+    public render(immediately?: boolean): void;
+    public scrollToNow(): void;
+    public setCalendarColor(calendarId: string, option: ICalendarColor, silent?: boolean): void;
+    public setCalendars(calendars: ICalendarInfo[]): void;
+    public setDate(date: Date | string): void;
+    public setOptions(options: IOptions, silent?: boolean): void;
+    public setTheme(theme: object): string[];
+    public today(): void;
+    public toggleSchedules(calendarId: string, toHide: boolean, render?: boolean): void;
+    public toggleScheduleView(enabled: boolean): void;
+    public toggleTaskView(enabled: boolean): void;
+    public updateSchedule(scheduleId: string, calendarId: string, scheduleData: ISchedule, silent?: boolean): void;
+    public off(eventName?: string | object | EventHandlerType, handler?: EventHandlerType | string): void;
+    public on(event: CustomEventType | IEvents, handler?: EventHandlerType): void;
 }


### PR DESCRIPTION
fixes: #383 


### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

delcaring modules AMD/CommonJS style is an old format. Also it's useful to export interfaces too, if we wanted to use these types for `@toast-ui/react-calendar` it could be something like:

```
declare module '@toast-ui/react-calendar' {
  import * as React from 'react'
  import { IOptions } from 'tui-calendar'

  const TuiCalendar: React.ComponentType<IOptions>
  export default TuiCalendar
}
```

They are pretty much impossible with the current definitions.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
