### PR TITLE
Fix : resolve end time issue 23:25 => 00:00(next day) - for feat/dooray branch

### DIFF
--- a/src/js/common/datetime.js
+++ b/src/js/common/datetime.js
@@ -601,6 +601,24 @@ datetime = {
         d2 = parseInt(datetime.format(d2, format), 10);
 
         return d1 <= d && d <= d2;
+    },
+
+    isStartOfDay: function(d) {
+        return !datetime.compare(datetime.start(d), d);
+    },
+
+    convertStartDayToLastDay: function(d) {
+        var date = new TZDate(d);
+        var isStartOfDay = datetime.isStartOfDay(d);
+
+        return isStartOfDay ? date.setDate(date.getDate() - 1) : date;
+    },
+
+    getStartOfNextDay: function(d) {
+        var date = datetime.start(d);
+        date.setHours(24);
+
+        return date;
     }
 };
 

--- a/src/js/controller/base.js
+++ b/src/js/controller/base.js
@@ -73,9 +73,15 @@ function Base(options) {
  * @returns {array} contain dates.
  */
 Base.prototype._getContainDatesInSchedule = function(schedule) {
+    var scheduleStart = schedule.getStarts();
+    var scheduleEnd = schedule.getEnds();
+    var start = datetime.start(scheduleStart);
+    var equalStartEnd = datetime.compare(scheduleStart, scheduleEnd) === 0;
+    var endDate = equalStartEnd ? scheduleEnd : datetime.convertStartDayToLastDay(scheduleEnd);
+    var end = datetime.end(endDate);
     var range = datetime.range(
-        datetime.start(schedule.getStarts()),
-        datetime.end(schedule.getEnds()),
+        start,
+        end,
         datetime.MILLISECONDS_PER_DAY
     );
 

--- a/src/js/controller/viewMixin/month.js
+++ b/src/js/controller/viewMixin/month.js
@@ -163,7 +163,7 @@ var Month = {
 
             if (!model.isAllDay && viewModel.hasMultiDates) {
                 viewModel.renderStarts = datetime.start(start);
-                viewModel.renderEnds = datetime.end(end);
+                viewModel.renderEnds = datetime.convertStartDayToLastDay(end);
             }
         });
     },

--- a/src/js/handler/time/creation.js
+++ b/src/js/handler/time/creation.js
@@ -233,7 +233,7 @@ TimeCreation.prototype._createSchedule = function(eventData) {
 
     baseDate = new TZDate(relatedView.getDate());
     dateStart = datetime.start(baseDate);
-    dateEnd = datetime.end(baseDate);
+    dateEnd = datetime.getStartOfNextDay(baseDate);
     start = common.limitDate(createRange[0], dateStart, dateEnd);
     end = common.limitDate(createRange[1], dateStart, dateEnd);
 

--- a/src/js/handler/time/creationGuide.js
+++ b/src/js/handler/time/creationGuide.js
@@ -128,7 +128,7 @@ TimeCreationGuide.prototype._getUnitData = function(relatedView) {
         viewHeight = relatedView.getViewBound().height,
         hourLength = viewOpt.hourEnd - viewOpt.hourStart,
         todayStart = datetime.parse(viewOpt.ymd),
-        todayEnd = datetime.end(todayStart);
+        todayEnd = datetime.getStartOfNextDay(todayStart);
 
     todayStart.setHours(0, 0, 0, 0);
     todayStart.setHours(viewOpt.hourStart);

--- a/test/app/handler/time/creationGuide.spec.js
+++ b/test/app/handler/time/creationGuide.spec.js
@@ -26,7 +26,7 @@ describe('handler/time.creation.guide', function() {
             getViewBound: jasmine.createSpy('TimeView#getViewBound')
         };
         var renderStart = new TZDate('2015-11-17T03:00:00');
-        var renderEnd = new TZDate('2015-11-17T23:59:59');
+        var renderEnd = new TZDate('2015-11-18T00:00:00');
         var expected,
             actual;
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* When the user directly inputs the end time as 00:00, the schedule is drawn in the grid cell of the next day and it does not render as intended.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
