### PR TITLE
fix: resolve incorrect diffdays on timezones area(fix #529)

### DIFF
--- a/src/js/common/datetime.js
+++ b/src/js/common/datetime.js
@@ -621,6 +621,13 @@ datetime = {
         date.setHours(24);
 
         return date;
+    },
+
+    getDiffDays: function(d1, d2) {
+        var _d1 = new TZDate(d1.getFullYear(), d1.getMonth(), d1.getDate()).getTime();
+        var _d2 = new TZDate(d2.getFullYear(), d2.getMonth(), d2.getDate()).getTime();
+
+        return Math.round((_d1 - _d2) / datetime.MILLISECONDS_PER_DAY);
     }
 };
 

--- a/src/js/common/datetime.js
+++ b/src/js/common/datetime.js
@@ -623,7 +623,7 @@ datetime = {
         return date;
     },
 
-    getDiffDays: function(d1, d2) {
+    getDateDifference: function(d1, d2) {
         var _d1 = new TZDate(d1.getFullYear(), d1.getMonth(), d1.getDate()).getTime();
         var _d2 = new TZDate(d2.getFullYear(), d2.getMonth(), d2.getDate()).getTime();
 

--- a/src/js/view/week/timeGrid.js
+++ b/src/js/view/week/timeGrid.js
@@ -264,7 +264,7 @@ TimeGrid.prototype._getHourmarkerViewModel = function(now, grids, range) {
         var dateDifference;
 
         hourmarker.setMinutes(hourmarker.getMinutes() + timezoneDifference);
-        dateDifference = datetime.getDiffDays(hourmarker, now);
+        dateDifference = datetime.getDateDifference(hourmarker, now);
 
         hourmarkerTimzones.push({
             hourmarker: hourmarker,
@@ -313,7 +313,7 @@ TimeGrid.prototype._getTimezoneViewModel = function(currentHours, timezonesColla
         timeSlots = getHoursLabels(opt, currentHours >= 0, timezoneDifference, styles);
 
         hourmarker.setMinutes(hourmarker.getMinutes() + timezoneDifference);
-        dateDifference = datetime.getDiffDays(hourmarker, now);
+        dateDifference = datetime.getDateDifference(hourmarker, now);
 
         if (index > 0) {
             backgroundColor = styles.additionalTimezoneBackgroundColor;

--- a/src/js/view/week/timeGrid.js
+++ b/src/js/view/week/timeGrid.js
@@ -264,7 +264,7 @@ TimeGrid.prototype._getHourmarkerViewModel = function(now, grids, range) {
         var dateDifference;
 
         hourmarker.setMinutes(hourmarker.getMinutes() + timezoneDifference);
-        dateDifference = hourmarker.getDate() - now.getDate();
+        dateDifference = datetime.getDiffDays(hourmarker, now);
 
         hourmarkerTimzones.push({
             hourmarker: hourmarker,
@@ -313,7 +313,7 @@ TimeGrid.prototype._getTimezoneViewModel = function(currentHours, timezonesColla
         timeSlots = getHoursLabels(opt, currentHours >= 0, timezoneDifference, styles);
 
         hourmarker.setMinutes(hourmarker.getMinutes() + timezoneDifference);
-        dateDifference = hourmarker.getDate() - now.getDate();
+        dateDifference = datetime.getDiffDays(hourmarker, now);
 
         if (index > 0) {
             backgroundColor = styles.additionalTimezoneBackgroundColor;

--- a/test/app/datetime.spec.js
+++ b/test/app/datetime.spec.js
@@ -474,4 +474,15 @@ describe('datetime', function() {
         var month = new TZDate('2015-07-15T00:00:00+09:00');
         expect(dt.endDateOfMonth(month)).toEqual(new TZDate('2015-07-31T23:59:59+09:00'));
     });
+
+    it('getDiffDays', function() {
+        var d1 = new TZDate('2020-02-29T09:30:30');
+        var d2 = new TZDate('2020-02-29T23:00:00');
+        var d3 = new TZDate('2020-03-01T23:00:00');
+        var d4 = new TZDate('2020-02-27T00:30:00');
+
+        expect(dt.getDiffDays(d1, d2)).toEqual(0);
+        expect(dt.getDiffDays(d1, d3)).toEqual(-1);
+        expect(dt.getDiffDays(d1, d4)).toEqual(2);
+    });
 });

--- a/test/app/datetime.spec.js
+++ b/test/app/datetime.spec.js
@@ -476,13 +476,17 @@ describe('datetime', function() {
     });
 
     it('getDiffDays', function() {
-        var d1 = new TZDate('2020-02-29T09:30:30');
-        var d2 = new TZDate('2020-02-29T23:00:00');
-        var d3 = new TZDate('2020-03-01T23:00:00');
-        var d4 = new TZDate('2020-02-27T00:30:00');
+        var d1 = new TZDate('2020-02-29T09:30:30+09:00');
+        var d2 = new TZDate('2020-02-29T23:00:00+09:00');
+        var d3 = new TZDate('2020-03-01T23:00:00+09:00');
+        var d4 = new TZDate('2020-02-27T00:30:00+09:00');
+        var d5 = new TZDate('2012-03-02T00:00:00+09:00')
+        var d6 = new TZDate('2012-03-01T03:00:00+09:00')
 
-        expect(dt.getDiffDays(d1, d2)).toEqual(0);
-        expect(dt.getDiffDays(d1, d3)).toEqual(-1);
-        expect(dt.getDiffDays(d1, d4)).toEqual(2);
+        expect(dt.getDateDifference(d1, d2)).toEqual(0);
+        expect(dt.getDateDifference(d1, d3)).toEqual(-1);
+        expect(dt.getDateDifference(d1, d4)).toEqual(2);
+        expect(dt.getDateDifference(d5, d6)).toEqual(1);
     });
+
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* If you use multiple time zones, the date difference is incorrectly displayed on the last and first day of the month.
#### AS-IS
![스크린샷 2020-03-01 12 42 07](https://user-images.githubusercontent.com/43128697/75746113-84867480-5d5c-11ea-8c6a-5b5328ad6ebe.png)

#### TO-BE
![스크린샷 2020-03-03 12 43 17](https://user-images.githubusercontent.com/43128697/75746209-e34bee00-5d5c-11ea-9710-bad2855be6c5.png)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
