### PR TITLE
Fix: improved the location of the arrows in the default schedule details popup(improvement #568)

### DIFF
--- a/src/js/view/popup/scheduleDetailPopup.js
+++ b/src/js/view/popup/scheduleDetailPopup.js
@@ -155,6 +155,8 @@ ScheduleDetailPopup.prototype._setPopupPositionAndArrowDirection = function(even
 
     this._scheduleEl = blockEl;
 
+    console.log(this.layer);
+
     pos = this._calcRenderingData(layerSize, containerBound, scheduleBound);
     this.layer.setPosition(pos.x, pos.y);
     this._setArrowDirection(pos.arrow);
@@ -176,10 +178,12 @@ ScheduleDetailPopup.prototype._getYAndArrowTop = function(
     containerTop,
     containerBottom
 ) {
-    var scheduleVerticalCenter = (scheduleBoundTop + scheduleBoundBottom) / 2;
-    var y = scheduleVerticalCenter - (layerHeight / 2);
+    var scheduleVerticalCenter, y, arrowTop;
     var ARROW_WIDTH_HALF = 8;
-    var arrowTop;
+
+    scheduleBoundTop = scheduleBoundTop < 0 ? 0 : scheduleBoundTop;
+    scheduleVerticalCenter = (scheduleBoundTop + scheduleBoundBottom) / 2;
+    y = scheduleVerticalCenter - (layerHeight / 2);
 
     if (y < containerTop) {
         y = 0;
@@ -189,6 +193,10 @@ ScheduleDetailPopup.prototype._getYAndArrowTop = function(
         arrowTop = scheduleVerticalCenter - y - containerTop - ARROW_WIDTH_HALF;
     } else {
         y -= containerTop;
+    }
+
+    if (arrowTop < 0 || arrowTop > layerHeight) {
+        arrowTop = '50%';
     }
 
     /**

--- a/src/js/view/popup/scheduleDetailPopup.js
+++ b/src/js/view/popup/scheduleDetailPopup.js
@@ -155,8 +155,6 @@ ScheduleDetailPopup.prototype._setPopupPositionAndArrowDirection = function(even
 
     this._scheduleEl = blockEl;
 
-    console.log(this.layer);
-
     pos = this._calcRenderingData(layerSize, containerBound, scheduleBound);
     this.layer.setPosition(pos.x, pos.y);
     this._setArrowDirection(pos.arrow);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* AS-IS


<img width="796" alt="스크린샷 2020-04-27 18 06 32" src="https://user-images.githubusercontent.com/43128697/80354605-eb825e80-88b1-11ea-9533-f10a13f4be22.png">



* TO-BE
<img width="1210" alt="스크린샷 2020-04-27 18 04 58" src="https://user-images.githubusercontent.com/43128697/80354637-f50bc680-88b1-11ea-9108-1469cdb77242.png">


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
