### PR TITLE
Remove zoom:1 from variables.styl:clearfix()

### DIFF
--- a/src/css/variables.styl
+++ b/src/css/variables.styl
@@ -36,7 +36,6 @@ vendor(prop, args)
     {prop} args
 
 clearfix()
-    zoom: 1;
     &:after
         content: '';
         display: block;


### PR DESCRIPTION
As of https://css-tricks.com/snippets/css/clear-fix/ `zoom: 1` is necessary
for IE 6 and IE 7, but according to README.md TUI Calendar runs on IE 9+.

zoom: 1 causes warnings in Firefox.