### PR TITLE
Remove not needed util.bind

### DIFF
--- a/src/js/handler/daygrid/core.js
+++ b/src/js/handler/daygrid/core.js
@@ -74,10 +74,11 @@ var dayGridCore = {
     /**
      * @param {view} view - view instance.
      * @param {TZDate} startDate - start date
-     * @returns {function|boolean} function that return schedule data by mouse events.
+     * @returns {object} schedule data by mouse events.
      */
     _retriveScheduleDataFromDate: function(view, startDate) {
         var weekdayView = view.children.single(),
+            xIndex = 0,
             datesInRange,
             dragStartXIndex = 0,
             grids,
@@ -93,36 +94,22 @@ var dayGridCore = {
 
         util.forEach(range, function(date, index) {
             if (datetime.isSameDate(date, startDate)) {
-                dragStartXIndex = index;
+                xIndex = dragStartXIndex = index;
             }
         });
 
-        /**
-         * @param {TZDate} targetDate - target date
-         * @returns {object} schedule data.
-         */
-        return function(targetDate) {
-            var xIndex = 0;
+        // apply limitation of creation schedule X index.
+        xIndex = mmax(xIndex, 0);
+        xIndex = mmin(xIndex, datesInRange - 1);
 
-            util.forEach(range, function(date, index) {
-                if (datetime.isSameDate(date, targetDate)) {
-                    xIndex = index;
-                }
-            });
-
-            // apply limitation of creation schedule X index.
-            xIndex = mmax(xIndex, 0);
-            xIndex = mmin(xIndex, datesInRange - 1);
-
-            return {
-                relatedView: view,
-                dragStartXIndex: dragStartXIndex,
-                datesInRange: datesInRange,
-                xIndex: xIndex,
-                triggerEvent: 'manual',
-                grids: grids,
-                range: range
-            };
+        return {
+            relatedView: view,
+            dragStartXIndex: dragStartXIndex,
+            datesInRange: datesInRange,
+            xIndex: xIndex,
+            triggerEvent: 'manual',
+            grids: grids,
+            range: range
         };
     }
 };

--- a/src/js/handler/daygrid/creation.js
+++ b/src/js/handler/daygrid/creation.js
@@ -322,10 +322,7 @@ DayGridCreation.prototype._onDblClick = function(clickEventData) {
  * @param {Schedule} schedule - schedule instance
  */
 DayGridCreation.prototype.invokeCreationClick = function(schedule) {
-    var getScheduleDataFunc, scheduleData;
-
-    getScheduleDataFunc = this._retriveScheduleDataFromDate(this.view, schedule.start);
-    scheduleData = getScheduleDataFunc(schedule.start);
+    var scheduleData = this._retriveScheduleDataFromDate(this.view, schedule.start);
 
     this.fire('click', scheduleData);
 

--- a/src/js/handler/month/guide.js
+++ b/src/js/handler/month/guide.js
@@ -6,7 +6,6 @@
 
 var util = require('tui-code-snippet');
 var config = require('../../config'),
-    common = require('../../common/common'),
     domutil = require('../../common/domutil'),
     datetime = require('../../common/datetime'),
     TZDate = require('../../common/timezone').Date,
@@ -25,8 +24,6 @@ var mmax = Math.max,
  * @param {Month} monthView - Month view instance
  */
 function MonthGuide(options, monthView) {
-    var self = this;
-
     /**
      * @type {object}
      */
@@ -58,13 +55,6 @@ function MonthGuide(options, monthView) {
     this.days = monthView.children.single().getRenderDateRange().length;
 
     /**
-     * @type {function}
-     */
-    this.ratio = util.bind(function(value) {
-        return common.ratio(self.days, 100, value);
-    });
-
-    /**
      * start coordinate of guide effect. (x, y) (days, weeks) effect can't
      *  start lower than this coordinate.
      * @type {number[]}
@@ -90,7 +80,7 @@ MonthGuide.prototype.destroy = function() {
     this.clear();
 
     this.options = this.view = this.weeks = this.days =
-        this.ratio = this.startCoord = this.guideElements = null;
+        this.startCoord = this.guideElements = null;
 };
 
 MonthGuide.prototype.clearGuideElement = function() {

--- a/src/js/handler/time/core.js
+++ b/src/js/handler/time/core.js
@@ -51,7 +51,7 @@ var timeCore = {
          * @param {object} [extend] - object to extend event data before return.
          * @returns {object} - common event data for time.*
          */
-        return util.bind(function(mouseEvent, extend) {
+        return function(mouseEvent, extend) {
             var mouseY = Point.n(domevent.getMousePosition(mouseEvent, container)).y,
                 gridY = common.ratio(viewHeight, hourLength, mouseY),
                 timeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(gridY)),
@@ -71,47 +71,40 @@ var timeCore = {
                 nearestGridTimeY: nearestGridTimeY,
                 triggerEvent: mouseEvent.type
             }, extend);
-        }, this);
+        };
     },
 
     /**
      * Get function to makes event data from Time and mouseEvent
      * @param {Time} timeView - Instance of time view.
-     * @param {number} xIndex - Time view index
-     * @returns {function} - Function that return event data from mouse event.
+     * @param {TZDate} startDate - start date
+     * @param {TZDate} endDate - end date
+     * @param {number} hourStart Can limit of render hour start.
+     * @returns {object} - common event data for time.* from mouse event.
      */
-    _retriveScheduleDataFromDate: function(timeView) {
+    _retriveScheduleDataFromDate: function(timeView, startDate, endDate, hourStart) {
         var viewTime = timeView.getDate();
+        var gridY, timeY, nearestGridY, nearestGridTimeY, nearestGridEndY, nearestGridEndTimeY;
 
-        /**
-         * @param {TZDate} startDate - start date
-         * @param {TZDate} endDate - end date
-         * @param {number} hourStart Can limit of render hour start.
-         * @returns {object} - common event data for time.*
-         */
-        return util.bind(function(startDate, endDate, hourStart) {
-            var gridY, timeY, nearestGridY, nearestGridTimeY, nearestGridEndY, nearestGridEndTimeY;
+        gridY = startDate.getHours() - hourStart + getNearestHour(startDate.getMinutes());
+        timeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(gridY));
+        nearestGridY = gridY;
+        nearestGridTimeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(nearestGridY));
+        nearestGridEndY = endDate.getHours() - hourStart + getNearestHour(endDate.getMinutes());
+        nearestGridEndTimeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(nearestGridEndY));
 
-            gridY = startDate.getHours() - hourStart + getNearestHour(startDate.getMinutes());
-            timeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(gridY));
-            nearestGridY = gridY;
-            nearestGridTimeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(nearestGridY));
-            nearestGridEndY = endDate.getHours() - hourStart + getNearestHour(endDate.getMinutes());
-            nearestGridEndTimeY = new TZDate(viewTime).addMinutes(datetime.minutesFromHours(nearestGridEndY));
-
-            return util.extend({
-                target: timeView,
-                relatedView: timeView,
-                gridY: gridY,
-                timeY: timeY,
-                nearestGridY: nearestGridY,
-                nearestGridTimeY: nearestGridTimeY,
-                nearestGridEndY: nearestGridEndY,
-                nearestGridEndTimeY: nearestGridEndTimeY,
-                triggerEvent: 'manual',
-                hourStart: hourStart
-            });
-        }, this);
+        return {
+            target: timeView,
+            relatedView: timeView,
+            gridY: gridY,
+            timeY: timeY,
+            nearestGridY: nearestGridY,
+            nearestGridTimeY: nearestGridTimeY,
+            nearestGridEndY: nearestGridEndY,
+            nearestGridEndTimeY: nearestGridEndTimeY,
+            triggerEvent: 'manual',
+            hourStart: hourStart
+        };
     },
 
     /**

--- a/src/js/handler/time/creation.js
+++ b/src/js/handler/time/creation.js
@@ -369,7 +369,7 @@ TimeCreation.prototype.invokeCreationClick = function(schedule) {
             datetime.MILLISECONDS_PER_DAY),
         hourStart = opt.hourStart,
         targetDate = schedule.start;
-    var getScheduleDataFunc, eventData, timeView;
+    var eventData, timeView;
 
     util.forEach(range, function(date, index) {
         if (datetime.isSameDate(date, targetDate)) {
@@ -382,8 +382,7 @@ TimeCreation.prototype.invokeCreationClick = function(schedule) {
         timeView = this.timeGridView.children.toArray()[0];
     }
 
-    getScheduleDataFunc = this._retriveScheduleDataFromDate(timeView);
-    eventData = getScheduleDataFunc(schedule.start, schedule.end, hourStart);
+    eventData = this._retriveScheduleDataFromDate(timeView, schedule.start, schedule.end, hourStart);
 
     this.fire('timeCreationClick', eventData);
 

--- a/src/js/view/popup/scheduleDetailPopup.js
+++ b/src/js/view/popup/scheduleDetailPopup.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Floating layer for  showing detail schedule
+ * @fileoverview Floating layer for showing detail schedule
  * @author NHN FE Development Lab <dl_javascript@nhn.com>
  */
 'use strict';


### PR DESCRIPTION
`util.bind(function(){…}, this)` makes no sense, as the `this` is anyway set correctly.  In particular when this is rewritten as `(function(){…}).bind(this)` eslint says this is pointless call.

In month/guide.js:this.ratio the util.bind is (at least looks so) useless, as there is no parameter to bind to.