### PR TITLE
Substitute util.bind with Function.bind

### DIFF
--- a/src/js/common/autoScroll.js
+++ b/src/js/common/autoScroll.js
@@ -148,7 +148,7 @@ AutoScroll.prototype._onMouseDown = function(mouseDownEvent) {
     }
 
     window.clearInterval(this._intervalID);
-    this._intervalID = window.setInterval(util.bind(this._onTick, this), SCROLL_INTERVAL);
+    this._intervalID = window.setInterval(this._onTick.bind(this), SCROLL_INTERVAL);
 
     domevent.on(global, {
         'mousemove': this._onMouseMove,

--- a/src/js/common/common.js
+++ b/src/js/common/common.js
@@ -150,7 +150,7 @@ module.exports = {
     },
 
     /**
-     * Set 'title' attribute for all elements that has exceeded content in
+     * Set 'title' attribute for all elements that have exceeded content in
      * container
      * @param {string} selector - CSS selector {@see domutil#find}
      * @param {HTMLElement} container - container element

--- a/src/js/common/reqAnimFrame.js
+++ b/src/js/common/reqAnimFrame.js
@@ -4,7 +4,6 @@
  */
 'use strict';
 
-var util = require('tui-code-snippet');
 var requestFn,
     cancelFn;
 
@@ -40,7 +39,7 @@ module.exports = {
      * @returns {number} Unique id
      */
     requestAnimFrame: function(fn, context) {
-        return requestFn.call(global, util.bind(fn, context));
+        return requestFn.call(global, fn.bind(context));
     },
 
     /**

--- a/src/js/factory/controller.js
+++ b/src/js/factory/controller.js
@@ -20,7 +20,7 @@ function mixin(from, to, propertyName) {
     var obj = to[propertyName] = {};
 
     util.forEach(from, function(method, methodName) {
-        obj[methodName] = util.bind(method, to);
+        obj[methodName] = method.bind(to);
     });
 }
 

--- a/src/js/handler/time/core.js
+++ b/src/js/handler/time/core.js
@@ -49,7 +49,7 @@ var timeCore = {
         /**
          * @param {MouseEvent} mouseEvent - mouse event object to get common event data.
          * @param {object} [extend] - object to extend event data before return.
-         * @returns {object} - common event data for time.*
+         * @returns {object} - common event data for time
          */
         return function(mouseEvent, extend) {
             var mouseY = Point.n(domevent.getMousePosition(mouseEvent, container)).y,
@@ -80,7 +80,7 @@ var timeCore = {
      * @param {TZDate} startDate - start date
      * @param {TZDate} endDate - end date
      * @param {number} hourStart Can limit of render hour start.
-     * @returns {object} - common event data for time.* from mouse event.
+     * @returns {object} - common event data for time from mouse event.
      */
     _retriveScheduleDataFromDate: function(timeView, startDate, endDate, hourStart) {
         var viewTime = timeView.getDate();

--- a/src/js/view/week/timeGrid.js
+++ b/src/js/view/week/timeGrid.js
@@ -545,7 +545,7 @@ TimeGrid.prototype.attachEvent = function() {
     clearTimeout(this.timerID);
     this.intervalID = this.timerID = this.rAnimationFrameID = null;
 
-    this.timerID = setTimeout(util.bind(this.onTick, this), (SIXTY_SECONDS - new TZDate().getSeconds()) * 1000);
+    this.timerID = setTimeout(this.onTick.bind(this), (SIXTY_SECONDS - new TZDate().getSeconds()) * 1000);
 
     domevent.on(this.stickyContainer, 'click', this._onClickStickyContainer, this);
 };
@@ -600,7 +600,7 @@ TimeGrid.prototype.onTick = function() {
     }
 
     if (!this.intervalID) {
-        this.intervalID = setInterval(util.bind(this.onTick, this), HOURMARKER_REFRESH_INTERVAL);
+        this.intervalID = setInterval(this.onTick.bind(this), HOURMARKER_REFRESH_INTERVAL);
     }
     this.refreshHourmarker();
 };


### PR DESCRIPTION
As of https://caniuse.com/#feat=mdn-javascript_builtins_function_bind Function.bind is supported in IE +9, Edge +12 , Firefox +4, Chrome +7, Safari +5.1.

ScheduleCreationPopup._onClickListeners() uses Function.bind since April 2018, and TimeCreationGuide._onDrag uses it since Mai 2017, so the aforementioned browser versions are required that long.

• Replace util.bind(x,y) with x.bind(y)
• Update README.md with the minimal supported versions.

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change