### PR TITLE
perf: css/popup.styl: compress two identical sections into one

### DIFF
--- a/src/css/icons.styl
+++ b/src/css/icons.styl
@@ -7,7 +7,6 @@
 }
 
 .{css-prefix}icon.{css-prefix}ic-title
-    top: 2px
     background: url('image/ic-subject.png') no-repeat
 
 .{css-prefix}icon.{css-prefix}ic-location

--- a/src/css/icons.styl
+++ b/src/css/icons.styl
@@ -7,6 +7,7 @@
 }
 
 .{css-prefix}icon.{css-prefix}ic-title
+    top: 2px
     background: url('image/ic-subject.png') no-repeat
 
 .{css-prefix}icon.{css-prefix}ic-location

--- a/src/css/popup.styl
+++ b/src/css/popup.styl
@@ -105,9 +105,6 @@
 .{css-prefix}popup-section-item .{css-prefix}icon
     position: relative
 
-.{css-prefix}icon.{css-prefix}ic-title
-    top: 2px
-
 .{css-prefix}popup-section-item .{css-prefix}content
     text-align: left
     display: inline-block
@@ -161,13 +158,11 @@
     border-top: none
     border-radius: 0 0 2px 2px
     width: 100%
+    display: none
 
 .{css-prefix}dropdown:hover .{css-prefix}dropdown-menu
     border: 1px solid #bbbbbb
     border-top: none
-
-.{css-prefix}dropdown-menu
-    display: none
 
 .{css-prefix}open .{css-prefix}dropdown-menu
         display: block
@@ -375,8 +370,6 @@ input[type='checkbox'].{css-prefix}checkbox-round + span
   height: 12px
   background-size: 12px
   position: relative
-
-.{css-prefix}popup-detail .{css-prefix}icon
   margin-right: 8px
 
 .{css-prefix}popup-detail .{css-prefix}icon.{css-prefix}ic-location-b


### PR DESCRIPTION
There were two subsequent sections  `.{css-prefix}popup-detail .{css-prefix}icon`, which can be merged into a single section.

Likewise, the definitions of `.{css-prefix}dropdown-menu` and `.{css-prefix}icon.{css-prefix}ic-title` were spread over two places.

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

