### PR TITLE
perf: remove a <span ... class="ic-private"> from scheduleDetailPopup.hbs

### DIFF
--- a/src/js/view/template/popup/scheduleDetailPopup.hbs
+++ b/src/js/view/template/popup/scheduleDetailPopup.hbs
@@ -2,7 +2,6 @@
   <div class="{{CSS_PREFIX}}popup-container">
     <div class="{{CSS_PREFIX}}popup-section {{CSS_PREFIX}}section-header">
       <div>
-        <span class="{{CSS_PREFIX}}schedule-private {{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-private"></span>
         <span class="{{CSS_PREFIX}}schedule-title">{{schedule.title}}</span>
       </div>
       <div class="{{CSS_PREFIX}}popup-detail-date {{CSS_PREFIX}}content">{{{popupDetailDate-tmpl schedule.isAllDay schedule.start schedule.end}}}</div>


### PR DESCRIPTION
The popup detail schedule contains:
```html
  <span class="tui-full-calendar-schedule-private tui-full-calendar-icon tui-full-calendar-ic-private"></span>
```

which expands to:
```css
.tui-full-calendar-icon.tui-full-calendar-ic-private {
    background: url(data:image/png;base64,...TkSuQmCC) no-repeat;
}

.tui-full-calendar-popup-detail .tui-full-calendar-schedule-private {
    display: none;
    width: 16px;
    height: 16px;
}

.tui-full-calendar-popup-detail .tui-full-calendar-icon {
    position: relative;
    margin-right: 8px;
}
```
All in all the `<span>` does nothing: no background image is shown.

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change