### PR TITLE
fix#636: make sure the top of scheduleDetailPopup is non-negative

### DIFF
--- a/src/js/view/popup/scheduleDetailPopup.js
+++ b/src/js/view/popup/scheduleDetailPopup.js
@@ -187,7 +187,7 @@ ScheduleDetailPopup.prototype._getYAndArrowTop = function(
         y = 0;
         arrowTop = scheduleVerticalCenter - containerTop - ARROW_WIDTH_HALF;
     } else if (y + layerHeight > containerBottom) {
-        y = containerBottom - layerHeight - containerTop;
+        y = Math.max(containerBottom - layerHeight - containerTop, 0);
         arrowTop = scheduleVerticalCenter - y - containerTop - ARROW_WIDTH_HALF;
     } else {
         y -= containerTop;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

When the body of the schedule is very long, TUI.calendar can set the top of the detail popup to be negative.  This makes reading the popup impossible, as it is not possible to scroll above the top.

With this change the top is set to be at least zero.  If the popup exceeds the viewport height, the window is enlarged and user can scroll down to read the whole popup.