### PR TITLE
fix: resolve schedule rendering issues on month view (#646)

### DIFF
--- a/src/js/common/datetime.js
+++ b/src/js/common/datetime.js
@@ -644,6 +644,12 @@ datetime = {
         var withinDay = diffDays === -1 && diffHours < 24 && datetime.isStartOfDay(end);
 
         return !datetime.isSameDate(start, end) && !withinDay;
+    },
+
+    renderEnd: function(start, end) {
+        return datetime.hasMultiDates(start, end) && datetime.isStartOfDay(end) ?
+            datetime.convertStartDayToLastDay(end) :
+            datetime.end(end);
     }
 };
 

--- a/src/js/controller/viewMixin/core.js
+++ b/src/js/controller/viewMixin/core.js
@@ -176,7 +176,6 @@ var Core = {
 
                     startDate = viewModel.getStarts();
                     endDate = viewModel.getEnds();
-
                     dateLength = datetime.range(
                         datetime.start(startDate),
                         datetime.renderEnd(startDate, endDate),

--- a/src/js/controller/viewMixin/core.js
+++ b/src/js/controller/viewMixin/core.js
@@ -156,7 +156,7 @@ var Core = {
      * @param {function} [iteratee] - iteratee function invoke each view models
      */
     positionViewModels: function(start, end, matrices, iteratee) {
-        var ymdListToRender, endTime;
+        var ymdListToRender;
 
         ymdListToRender = util.map(
             datetime.range(start, end, datetime.MILLISECONDS_PER_DAY),
@@ -168,7 +168,7 @@ var Core = {
         forEachArr(matrices, function(matrix) {
             forEachArr(matrix, function(column) {
                 forEachArr(column, function(viewModel, index) {
-                    var ymd, dateLength, isSameDate, startDate, endDate;
+                    var ymd, dateLength, startDate, endDate;
 
                     if (!viewModel) {
                         return;
@@ -177,21 +177,13 @@ var Core = {
                     startDate = viewModel.getStarts();
                     endDate = viewModel.getEnds();
 
-                    ymd = datetime.format(startDate, 'YYYYMMDD');
-                    isSameDate = datetime.isSameDate(startDate, endDate);
-
-                    if (viewModel.hasMultiDates || isSameDate) {
-                        endTime = datetime.end(endDate);
-                    } else {
-                        endTime = datetime.convertStartDayToLastDay(endDate);
-                    }
-
                     dateLength = datetime.range(
                         datetime.start(startDate),
-                        endTime,
+                        datetime.renderEnd(startDate, endDate),
                         datetime.MILLISECONDS_PER_DAY
                     ).length;
 
+                    ymd = datetime.format(startDate, 'YYYYMMDD');
                     viewModel.top = index;
                     viewModel.left = util.inArray(ymd, ymdListToRender);
                     viewModel.width = dateLength;

--- a/src/js/controller/viewMixin/core.js
+++ b/src/js/controller/viewMixin/core.js
@@ -156,7 +156,7 @@ var Core = {
      * @param {function} [iteratee] - iteratee function invoke each view models
      */
     positionViewModels: function(start, end, matrices, iteratee) {
-        var ymdListToRender, endTime;
+        var ymdListToRender, endTime, isSameDate;
 
         ymdListToRender = util.map(
             datetime.range(start, end, datetime.MILLISECONDS_PER_DAY),
@@ -175,9 +175,14 @@ var Core = {
                     }
 
                     ymd = datetime.format(viewModel.getStarts(), 'YYYYMMDD');
-                    endTime = viewModel.hasMultiDates ?
-                        datetime.end(viewModel.getEnds()) :
-                        datetime.convertStartDayToLastDay(viewModel.getEnds());
+                    isSameDate = datetime.isSameDate(viewModel.getStarts(), viewModel.getEnds());
+
+                    if (viewModel.hasMultiDates || isSameDate) {
+                        endTime = datetime.end(viewModel.getEnds());
+                    } else {
+                        endTime = datetime.convertStartDayToLastDay(viewModel.getEnds());
+                    }
+
                     dateLength = datetime.range(
                         datetime.start(viewModel.getStarts()),
                         endTime,

--- a/src/js/controller/viewMixin/core.js
+++ b/src/js/controller/viewMixin/core.js
@@ -156,7 +156,7 @@ var Core = {
      * @param {function} [iteratee] - iteratee function invoke each view models
      */
     positionViewModels: function(start, end, matrices, iteratee) {
-        var ymdListToRender, endTime, isSameDate;
+        var ymdListToRender, endTime;
 
         ymdListToRender = util.map(
             datetime.range(start, end, datetime.MILLISECONDS_PER_DAY),
@@ -168,23 +168,26 @@ var Core = {
         forEachArr(matrices, function(matrix) {
             forEachArr(matrix, function(column) {
                 forEachArr(column, function(viewModel, index) {
-                    var ymd, dateLength;
+                    var ymd, dateLength, isSameDate, startDate, endDate;
 
                     if (!viewModel) {
                         return;
                     }
 
-                    ymd = datetime.format(viewModel.getStarts(), 'YYYYMMDD');
-                    isSameDate = datetime.isSameDate(viewModel.getStarts(), viewModel.getEnds());
+                    startDate = viewModel.getStarts();
+                    endDate = viewModel.getEnds();
+
+                    ymd = datetime.format(startDate, 'YYYYMMDD');
+                    isSameDate = datetime.isSameDate(startDate, endDate);
 
                     if (viewModel.hasMultiDates || isSameDate) {
-                        endTime = datetime.end(viewModel.getEnds());
+                        endTime = datetime.end(endDate);
                     } else {
-                        endTime = datetime.convertStartDayToLastDay(viewModel.getEnds());
+                        endTime = datetime.convertStartDayToLastDay(endDate);
                     }
 
                     dateLength = datetime.range(
-                        datetime.start(viewModel.getStarts()),
+                        datetime.start(startDate),
                         endTime,
                         datetime.MILLISECONDS_PER_DAY
                     ).length;

--- a/src/js/controller/viewMixin/month.js
+++ b/src/js/controller/viewMixin/month.js
@@ -163,7 +163,7 @@ var Month = {
 
             if (!model.isAllDay && viewModel.hasMultiDates) {
                 viewModel.renderStarts = datetime.start(start);
-                viewModel.renderEnds = datetime.convertStartDayToLastDay(end);
+                viewModel.renderEnds = datetime.renderEnd(start, end);
             }
         });
     },

--- a/src/js/controller/viewMixin/week.js
+++ b/src/js/controller/viewMixin/week.js
@@ -212,6 +212,7 @@ var Week = {
      * @returns {function} - filtering function
      */
     _makeHourRangeFilter: function(hStart, hEnd) {
+        // eslint-disable-next-line complexity
         return function(schedule) {
             var ownHourStart = schedule.model.start;
             var ownHourEnd = schedule.model.end;
@@ -241,9 +242,12 @@ var Week = {
     _addMultiDatesInfo: function(vColl) {
         vColl.each(function(viewModel) {
             var model = viewModel.model;
+            var start = model.getStarts();
+            var end = model.getEnds();
+
             viewModel.hasMultiDates = true;
-            viewModel.renderStarts = datetime.start(model.getStarts());
-            viewModel.renderEnds = datetime.convertStartDayToLastDay(model.getEnds());
+            viewModel.renderStarts = datetime.start(start);
+            viewModel.renderEnds = datetime.renderEnd(start, end);
         });
     },
 

--- a/src/js/handler/month/core.js
+++ b/src/js/handler/month/core.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /**
  * @fileoverview Module for calculate date by month view and mouse event object
  * @author NHN FE Development Lab <dl_javascript@nhn.com>
@@ -8,6 +9,7 @@ var util = require('tui-code-snippet');
 var common = require('../../common/common'),
     domutil = require('../../common/domutil'),
     domevent = require('../../common/domevent');
+var datetime = require('../../common/datetime');
 var mfloor = Math.floor;
 
 /**
@@ -91,7 +93,7 @@ function getMousePosDate(monthView) {
             y: y,
             sizeX: dayCount,
             sizeY: weekCount,
-            date: date,
+            date: datetime.end(date),
             weekdayView: weekdayView,
             triggerEvent: mouseEvent.type
         };

--- a/src/js/handler/month/core.js
+++ b/src/js/handler/month/core.js
@@ -8,7 +8,8 @@
 var util = require('tui-code-snippet');
 var common = require('../../common/common'),
     domutil = require('../../common/domutil'),
-    domevent = require('../../common/domevent');
+    domevent = require('../../common/domevent'),
+    datetime = require('../../common/datetime');
 var mfloor = Math.floor;
 
 /**

--- a/src/js/handler/month/core.js
+++ b/src/js/handler/month/core.js
@@ -9,7 +9,6 @@ var util = require('tui-code-snippet');
 var common = require('../../common/common'),
     domutil = require('../../common/domutil'),
     domevent = require('../../common/domevent');
-var datetime = require('../../common/datetime');
 var mfloor = Math.floor;
 
 /**

--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -676,12 +676,8 @@ ScheduleCreationPopup.prototype._validateForm = function(title, startDate, endDa
  * @returns {RangeDate} Returns the start and end time data that is the range date
  */
 ScheduleCreationPopup.prototype._getRangeDate = function(startDate, endDate, isAllDay) {
-    if (isAllDay) {
-        startDate.setHours(0, 0, 0);
-        endDate = datetime.isStartOfDay(endDate) ?
-            datetime.convertStartDayToLastDay(endDate) :
-            endDate.setHours(23, 59, 59);
-    }
+    var start = isAllDay ? datetime.start(startDate) : startDate;
+    var end = isAllDay ? datetime.renderEnd(startDate, endDate) : endDate;
 
     /**
      * @typedef {object} RangeDate
@@ -689,8 +685,8 @@ ScheduleCreationPopup.prototype._getRangeDate = function(startDate, endDate, isA
      * @property {TZDate} end end time
      */
     return {
-        start: new TZDate(startDate),
-        end: new TZDate(endDate)
+        start: new TZDate(start),
+        end: new TZDate(end)
     };
 };
 

--- a/test/app/handler/month/core.spec.js
+++ b/test/app/handler/month/core.spec.js
@@ -68,7 +68,7 @@ describe('handler:MonthCore', function() {
             y: 0,
             sizeX: 7,
             sizeY: 2,
-            date: new TZDate('2015-12-27T00:00:00+09:00'),
+            date: new TZDate('2015-12-27T23:59:59+09:00'),
             weekdayView: w1,
             triggerEvent: 'click'
         });
@@ -84,7 +84,7 @@ describe('handler:MonthCore', function() {
             y: 1,
             sizeX: 7,
             sizeY: 2,
-            date: new TZDate('2016-01-08T00:00:00+09:00'),
+            date: new TZDate('2016-01-08T23:59:59+09:00'),
             weekdayView: w2,
             triggerEvent: 'click'
         });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* fix: When the end time of the schedule is resized to the previous date in the monthly view, the schedule size rendered is restored (#646 **issue1**)

| AS-IS | TO-BE |
| --- | --- |
| ![tui-calendar-issue-646-1](https://user-images.githubusercontent.com/43128697/86193926-1de95a00-bb88-11ea-8966-2fbe10f70bfe.gif) | ![tui-calendar-issue-646-1-tobe](https://user-images.githubusercontent.com/43128697/86193947-2772c200-bb88-11ea-8564-2941097dfeed.gif) |


* fix : resolve midnight schedule on monthly view(#646 **issue2**)

| AS-IS | TO-BE |
| --- | --- |
| <img width="206" alt="스크린샷 2020-07-01 10 48 35" src="https://user-images.githubusercontent.com/43128697/86194111-9b14cf00-bb88-11ea-9dbd-6616ad685c88.png"> | <img width="479" alt="스크린샷 2020-07-01 10 49 19" src="https://user-images.githubusercontent.com/43128697/86194119-a23bdd00-bb88-11ea-8e7a-f5a11e3d39c0.png"> |

* fix: resolve allday schedule (start and end same midnight) issue on monthly view(fix #657)
To reproduce
1. on monthly view,
2. When adding a new schedule with the default schedule creation popup
3. enter start time `2020-07-23 00:00`, end time `2020-07-23 00:00` and 'All day' checked
![스크린샷 2020-07-23 20 36 29](https://user-images.githubusercontent.com/43128697/88282332-4ea25680-cd24-11ea-8b6d-0fc8d9d2ae54.png)


| **AS-IS** | **TO-BE** |
| ------ | ------ |
| ![스크린샷 2020-07-23 20 39 03](https://user-images.githubusercontent.com/43128697/88282616-de480500-cd24-11ea-8d4e-3fcfb8256388.png) | ![스크린샷 2020-07-23 20 42 22](https://user-images.githubusercontent.com/43128697/88282718-0afc1c80-cd25-11ea-8a50-21cd088f853c.png) |
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
