### PR TITLE
Calendar.prototype.changeView: tautology

### DIFF
--- a/src/js/factory/calendar.js
+++ b/src/js/factory/calendar.js
@@ -1582,7 +1582,7 @@ Calendar.prototype.changeView = function(newViewName, force) {
             dragHandler,
             options
         );
-    } else if (newViewName === 'week' || newViewName === 'day') {
+    } else if (newViewName === 'week') {
         created = _createWeekView(
             controller,
             layout.container,


### PR DESCRIPTION
`newViewName` is set previously to "week", if it was "day".