### PR TITLE
feat: Memorize the hidden calendars on toggleSchedules and reuse this in createSchedules

### DIFF
--- a/src/js/factory/calendar.js
+++ b/src/js/factory/calendar.js
@@ -759,7 +759,17 @@ Calendar.prototype._setAdditionalInternalOptions = function(options) {
  * ]);
  */
 Calendar.prototype.createSchedules = function(schedules, silent) {
-    util.forEach(schedules, function(obj) {
+    var calendars = this._controller.calendars;
+    schedules.forEach(function(obj) {
+        var i;
+        // emulates for IE9
+        // obj.isVisible = calendars.find(cal => cal.id === obj.calendarId)._isVisible !== false;
+        for (i in calendars) {
+            if (calendars[i].id === obj.calendarId) {
+                obj.isVisible = calendars[i]._isVisible !== false;
+                break;
+            }
+        }
         this._setScheduleColor(obj.calendarId, obj);
     }, this);
 
@@ -925,10 +935,15 @@ Calendar.prototype._getWeekDayRange = function(date, startDayOfWeek, workweek) {
  * @param {boolean} [render=true] - set true then render after change visible property each models
  */
 Calendar.prototype.toggleSchedules = function(calendarId, toHide, render) {
-    var ownSchedules = this._controller.schedules;
+    var ownSchedules = this._controller.schedules, calendars = this._controller.calendars, c;
 
     render = util.isExisty(render) ? render : true;
     calendarId = util.isArray(calendarId) ? calendarId : [calendarId];
+    for (c in calendars) {
+        if (~calendarId.indexOf(calendars[c].id)) {
+            calendars[c]._isVisible = !toHide;
+        }
+    }
 
     ownSchedules.each(function(schedule) {
         if (~util.inArray(schedule.calendarId, calendarId)) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

`Calendar.toggleSchedules()` iterates all loaded schedules and switches some of them on or off.  Schedules loaded later with `Calendar.createSchedules()` are displayed, even if the calendar was switched previously off with `Calendar.toggleSchedules()`.

This patch:
- memorizes in `toggleSchedules()` whether a calendar is shown or hidden (when `_isVisible` is undefined/missing or true, then the calendar is shown)
- in `createSchedules()` obtains from the calendar information, whether the latter is visible, and modifies the `isVisible` property of the schedules accordingly.

As TUI.calendar runs on IE9+ and the other recent version of browsers, it does support `Array.prototype.forEach`.  Replace `util.forEach()` with the former.

I have not run the code. I made a similar change which does run correctly on futuristic JavaScript and then I rewrote the code to work in the IE9+ environment.