### PR TITLE
docs: fix typo in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -290,7 +290,7 @@ var calendar = new Calendar('#calendar', {
         },
         grid: {
             header: {
-                header: 34
+                height: 34
             },
             footer: {
                 height: 10


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] It's submitted to right branch according to our branching model
- [X] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed key typo of `header` field to `height`, since `IMonthOptions.grid?` should implements `header?: { height?: number }`

https://github.com/nhn/tui.calendar/blob/a1d5e1c8df8184eec0f8a7c52ad6fe97b2a130ce/index.d.ts#L162