### PR TITLE
fix: treat `calendarId` as string type when finding selected calendar (fix #851)

### DIFF
--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -183,7 +183,7 @@ ScheduleCreationPopup.prototype._selectDropdownMenuItem = function(target) {
     if (domutil.hasClass(dropdown, config.classname('section-calendar'))) {
         domutil.find('.' + iconClassName, dropdownBtn).style.backgroundColor = bgColor;
         this._selectedCal = common.find(this.calendars, function(cal) {
-            return cal.id === domutil.getData(selectedItem, 'calendarId');
+            return String(cal.id) === domutil.getData(selectedItem, 'calendarId');
         });
     }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

* When creating a calendar instance using the default creation popup, if the [`CalendarProps`](https://nhn.github.io/tui.calendar/latest/CalendarProps) have an id with the `number type, then the selected calendar id cannot be found.
	* This comes from the wrong implementation when finding a selected calendar.
		* `domutil.getData` returns always the string type.
	* [If a selected calendar is missing, the popup passes just `null`.](https://github.com/nhn/tui.calendar/blob/master/src/js/view/popup/scheduleCreationPopup.js#L275)
* So this PR makes the popup find the selected calendar no matter what type of calendar id.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
