### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/js/common/model.js
+++ b/src/js/common/model.js
@@ -19,7 +19,7 @@ model = {
     /**
      * string trim
      * @param {string} str string to trim
-     * @returns {string} trimed string
+     * @returns {string} trimmed string
      */
     trim: function(str) {
         return str.replace(spaceRx, '');

--- a/src/js/common/point.js
+++ b/src/js/common/point.js
@@ -242,7 +242,7 @@ Point.prototype.ceil = function() {
 };
 
 /**
- * Ceil self coodinates.
+ * Ceil self coordinates.
  * @returns {Point} Point calculated.
  */
 Point.prototype._ceil = function() {
@@ -330,7 +330,7 @@ Point.prototype.toString = function() {
 };
 
 /**
- * Return coodinates to array. [x, y]
+ * Return coordinates to array. [x, y]
  * @returns {number[]} coordinate array.
  */
 Point.prototype.toArray = function() {

--- a/src/js/common/timezone.js
+++ b/src/js/common/timezone.js
@@ -40,7 +40,7 @@ var STANDARD_TO_DST = 1;
 var DST_TO_STANDARD = -1;
 
 /**
- * Get the timezone offset by timestampe
+ * Get the timezone offset by timestamp
  * @param {number} timestamp - timestamp
  * @returns {number} timezone offset
  * @private
@@ -52,7 +52,7 @@ function getTimezoneOffset(timestamp) {
 }
 
 /**
- * Get the custome timezone offset by timestampe
+ * Get the custom timezone offset by timestamp
  * @param {number} timestamp - timestamp
  * @returns {number} timezone offset
  * @private

--- a/src/js/handler/month/guide.js
+++ b/src/js/handler/month/guide.js
@@ -167,9 +167,9 @@ MonthGuide.prototype._getCoordByDate = function(date) {
 };
 
 /**
- * Get limited coordinate by supplied coodinates
+ * Get limited coordinate by supplied coordinates
  * @param {number[]} coord - coordinate need to limit
- * @param {number[]} [min] - minimum limitaion of coordinate
+ * @param {number[]} [min] - minimum limitation of coordinate
  * @param {number[]} [max] - maximum limitation of coordinate
  * @returns {number[]} limited coordiate
  */
@@ -362,7 +362,7 @@ MonthGuide.prototype._removeGuideElements = function(yCoords) {
 
 /**
  * Get excluded numbers in range
- * @param {number[]} range - the range. value must be sequencial.
+ * @param {number[]} range - the range. value must be sequential.
  * @param {number[]} numbers - numbers to check
  * @returns {number[]} excluded numbers
  */

--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -409,7 +409,7 @@ ScheduleCreationPopup.prototype._setDatepickerState = function(newState) {
 };
 
 /**
- * Set popup position and arrow direction to apear near guide element
+ * Set popup position and arrow direction to appear near guide element
  * @param {MonthCreationGuide|TimeCreationGuide|DayGridCreationGuide} guideBound - creation guide element
  */
 ScheduleCreationPopup.prototype._setPopupPositionAndArrowDirection = function(guideBound) {

--- a/src/js/view/popup/scheduleDetailPopup.js
+++ b/src/js/view/popup/scheduleDetailPopup.js
@@ -209,7 +209,7 @@ ScheduleDetailPopup.prototype._getScheduleModel = function(scheduleViewModel) {
 };
 
 /**
- * Set popup position and arrow direction to apear near guide element
+ * Set popup position and arrow direction to appear near guide element
  * @param {Event} event - creation guide element
  */
 ScheduleDetailPopup.prototype._setPopupPositionAndArrowDirection = function(event) {


### PR DESCRIPTION
There are small typos in:
- src/js/common/model.js
- src/js/common/point.js
- src/js/common/timezone.js
- src/js/handler/month/guide.js
- src/js/view/popup/scheduleCreationPopup.js
- src/js/view/popup/scheduleDetailPopup.js

Fixes:
- Should read `coordinates` rather than `coodinates`.
- Should read `timestamp` rather than `timestampe`.
- Should read `custom` rather than `custome`.
- Should read `sequential` rather than `sequencial`.
- Should read `appear` rather than `apear`.
- Should read `trimmed` rather than `trimed`.
- Should read `limitation` rather than `limitaion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md