### PR TITLE
fix: wrong private schedule assignment in default popup (resolve #927)

### DIFF
--- a/examples/js/app.js
+++ b/examples/js/app.js
@@ -218,6 +218,7 @@
             calendarId: calendar.id,
             title: title,
             isAllDay: isAllDay,
+            location: location,
             start: start,
             end: end,
             category: isAllDay ? 'allday' : 'time',
@@ -226,9 +227,6 @@
             bgColor: calendar.bgColor,
             dragBgColor: calendar.bgColor,
             borderColor: calendar.borderColor,
-            raw: {
-                location: location
-            },
             state: 'Busy'
         }]);
 
@@ -280,9 +278,7 @@
             dragBgColor: calendar.bgColor,
             borderColor: calendar.borderColor,
             location: scheduleData.location,
-            raw: {
-                class: scheduleData.raw['class']
-            },
+            isPrivate: scheduleData.isPrivate,
             state: scheduleData.state
         };
         if (calendar) {

--- a/examples/js/data/schedules.js
+++ b/examples/js/data/schedules.js
@@ -15,6 +15,7 @@ function ScheduleInfo() {
 
     this.title = null;
     this.body = null;
+    this.location = null;
     this.isAllday = false;
     this.start = null;
     this.end = null;
@@ -31,6 +32,7 @@ function ScheduleInfo() {
     this.isPending = false;
     this.isVisible = true;
     this.isReadOnly = false;
+    this.isPrivate = false;
     this.goingDuration = 0;
     this.comingDuration = 0;
     this.recurrenceRule = '';
@@ -41,7 +43,6 @@ function ScheduleInfo() {
         hasToOrCc: false,
         hasRecurrenceRule: false,
         location: null,
-        class: 'public', // or 'private'
         creator: {
             name: '',
             avatar: '',

--- a/src/js/controller/base.js
+++ b/src/js/controller/base.js
@@ -289,6 +289,10 @@ Base.prototype.updateSchedule = function(schedule, options) {
         schedule.set('isReadOnly', options.isReadOnly);
     }
 
+    if (!util.isUndefined(options.isPrivate)) {
+        schedule.set('isPrivate', options.isPrivate);
+    }
+
     if (options.location) {
         schedule.set('location', options.location);
     }

--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -745,7 +745,7 @@ ScheduleCreationPopup.prototype._getRangeDate = function(startDate, endDate, isA
 ScheduleCreationPopup.prototype._onClickUpdateSchedule = function(form) {
     var changes = common.getScheduleChanges(
         this._schedule,
-        ['calendarId', 'title', 'location', 'start', 'end', 'isAllDay', 'state'],
+        ['calendarId', 'title', 'location', 'start', 'end', 'isAllDay', 'state', 'isPrivate'],
         {
             calendarId: form.calendarId,
             title: form.title.value,
@@ -753,7 +753,8 @@ ScheduleCreationPopup.prototype._onClickUpdateSchedule = function(form) {
             start: form.start,
             end: form.end,
             isAllDay: form.isAllDay,
-            state: form.state
+            state: form.state,
+            isPrivate: form.isPrivate
         }
     );
 
@@ -763,11 +764,7 @@ ScheduleCreationPopup.prototype._onClickUpdateSchedule = function(form) {
      * @property {Schedule} schedule - schedule object to be updated
      */
     this.fire('beforeUpdateSchedule', {
-        schedule: util.extend({
-            raw: {
-                class: form.isPrivate ? 'private' : 'public'
-            }
-        }, this._schedule),
+        schedule: this._schedule,
         changes: changes,
         start: form.start,
         end: form.end,

--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -799,9 +799,7 @@ ScheduleCreationPopup.prototype._onClickCreateSchedule = function(form) {
         calendarId: form.calendarId,
         title: form.title.value,
         location: form.location.value,
-        raw: {
-            class: form.isPrivate ? 'private' : 'public'
-        },
+        isPrivate: form.isPrivate,
         start: form.start,
         end: form.end,
         isAllDay: form.isAllDay,

--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -367,12 +367,11 @@ ScheduleCreationPopup.prototype.render = function(viewModel) {
 ScheduleCreationPopup.prototype._makeEditModeData = function(viewModel) {
     var schedule = viewModel.schedule;
     var title, isPrivate, location, startDate, endDate, isAllDay, state;
-    var raw = schedule.raw || {};
     var calendars = this.calendars;
 
     var id = schedule.id;
     title = schedule.title;
-    isPrivate = raw['class'] === 'private';
+    isPrivate = schedule.isPrivate;
     location = schedule.location;
     startDate = schedule.start;
     endDate = schedule.end;
@@ -396,9 +395,6 @@ ScheduleCreationPopup.prototype._makeEditModeData = function(viewModel) {
         state: state,
         start: startDate,
         end: endDate,
-        raw: {
-            class: isPrivate ? 'private' : 'public'
-        },
         zIndex: this.layer.zIndex + 5,
         isEditMode: this._isEditMode
     };

--- a/src/js/view/week/dayGrid.js
+++ b/src/js/view/week/dayGrid.js
@@ -19,7 +19,7 @@ var mmax = Math.max,
 
 /**
  * @constructor
- * @extends {Weekday}
+ * @extends {View}
  * @param {string} name - view name
  * @param {object} options - options for DayGridSchedule view
  * @param {number} [options.heightPercent] - height percent of view

--- a/test/app/view/scheduleCreationPopup.spec.js
+++ b/test/app/view/scheduleCreationPopup.spec.js
@@ -15,13 +15,13 @@ describe('ScheduleCreationPopup date range picker', function() {
     var mockTimedViewModel = {
         start: '2015-05-01T09:00:00',
         end: '2015-05-01T10:00:00',
-        guide: []
+        guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
     };
     var mockAllDayViewModel = {
         start: '2015-05-01T09:00:00',
         end: '2015-05-01T10:00:00',
         isAllDay: true,
-        guide: []
+        guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
     };
 
     function getInputValue(inputId) {
@@ -88,6 +88,54 @@ describe('ScheduleCreationPopup date range picker', function() {
 
         expect(getInputValue(startPickerId)).toBe('2015-05-01 12:00');
         expect(getInputValue(endPickerId)).toBe('2015-05-01 13:00');
+    });
+});
+
+describe('ScheduleCreationPopup private schedule', function() {
+    var container, popup;
+    var mockViewModel = {
+        title: 'mock schedule',
+        start: '2015-05-01T09:00:00',
+        end: '2015-05-01T10:00:00',
+        guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
+    };
+    var clickEvent = new MouseEvent('click', {bubbles: true});
+
+    function togglePrivateButton() {
+        var privateButton = document.getElementById('tui-full-calendar-schedule-private');
+
+        privateButton.dispatchEvent(clickEvent);
+    }
+
+    function clickSaveButton() {
+        var saveButton = document.querySelector('.tui-full-calendar-popup-save');
+
+        saveButton.dispatchEvent(clickEvent);
+    }
+
+    beforeEach(function() {
+        fixture.load('view.html');
+        container = document.getElementById('container');
+        popup = new ScheduleCreationPopup(container, [], false);
+    });
+
+    afterEach(function() {
+        fixture.cleanup();
+        popup.destroy();
+    });
+
+    it('should be able to create private schedule', function() {
+        var result;
+        var spy = jasmine.createSpy('beforeCreateSchedule');
+        popup.on('beforeCreateSchedule', spy);
+        popup.render(mockViewModel);
+
+        togglePrivateButton();
+        clickSaveButton();
+
+        result = spy.calls.argsFor(0)[0];
+
+        expect(result.isPrivate).toBe(true);
     });
 });
 

--- a/test/app/view/scheduleCreationPopup.spec.js
+++ b/test/app/view/scheduleCreationPopup.spec.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var ScheduleCreationPopup = require('../../../src/js/view/popup/scheduleCreationPopup');
+var config = require('config');
+var domutil = require('common/domutil');
 var TZDate = require('common/timezone').Date;
+var ScheduleCreationPopup = require('../../../src/js/view/popup/scheduleCreationPopup');
 
 /**
  * NOTE: Due to external dependency(tui-date-picker) and testing environment,
@@ -10,8 +12,8 @@ var TZDate = require('common/timezone').Date;
  */
 describe('ScheduleCreationPopup date range picker', function() {
     var container, popup;
-    var startPickerId = 'tui-full-calendar-schedule-start-date';
-    var endPickerId = 'tui-full-calendar-schedule-end-date';
+    var startPickerId = config.cssPrefix + 'schedule-start-date';
+    var endPickerId = config.cssPrefix + 'schedule-end-date';
     var mockTimedViewModel = {
         start: new TZDate('2015-05-01T09:00:00'),
         end: new TZDate('2015-05-01T10:00:00'),
@@ -31,10 +33,9 @@ describe('ScheduleCreationPopup date range picker', function() {
     }
 
     function clickAllDaySection() {
-        var allDaySectionClassName = 'tui-full-calendar-section-allday';
         var clickEvent = new MouseEvent('click', {bubbles: true});
 
-        document.querySelector('.' + allDaySectionClassName).dispatchEvent(clickEvent);
+        document.querySelector(config.classname('.section-allday')).dispatchEvent(clickEvent);
     }
 
     beforeEach(function() {
@@ -49,8 +50,7 @@ describe('ScheduleCreationPopup date range picker', function() {
     });
 
     it('should render start & end dates on the date range picker', function() {
-        var popupClassName = 'tui-full-calendar-popup-container';
-        var popupNode = document.getElementsByClassName(popupClassName);
+        var popupNode = document.querySelector(config.classname('.popup-container'));
         popup.render(mockTimedViewModel);
 
         expect(popupNode).toBeDefined();
@@ -95,7 +95,7 @@ describe('ScheduleCreationPopup private schedule', function() {
     var container, popup;
 
     function getPrivateButton() {
-        return document.getElementById('tui-full-calendar-schedule-private');
+        return document.getElementById(config.cssPrefix + 'schedule-private');
     }
 
     function togglePrivateButton() {
@@ -103,7 +103,7 @@ describe('ScheduleCreationPopup private schedule', function() {
     }
 
     function clickSaveButton() {
-        var saveButton = document.querySelector('.tui-full-calendar-popup-save');
+        var saveButton = document.querySelector(config.classname('.popup-save'));
         saveButton.click();
     }
 
@@ -175,7 +175,7 @@ describe('ScheduleCreationPopup private schedule', function() {
         };
         popup.render(mockEditModeViewModel);
 
-        isPrivateEnabled = !getPrivateButton().classList.contains('tui-full-calendar-public');
+        isPrivateEnabled = !domutil.hasClass(getPrivateButton(), config.cssPrefix + 'public');
         expect(isPrivateEnabled).toBe(true);
     });
 });

--- a/test/app/view/scheduleCreationPopup.spec.js
+++ b/test/app/view/scheduleCreationPopup.spec.js
@@ -119,7 +119,7 @@ describe('ScheduleCreationPopup private schedule', function() {
     });
 
     it('should be able to create private schedule', function() {
-        var result;
+        var creationEventData;
         var mockViewModel = {
             title: 'mock schedule',
             start: new TZDate('2015-05-01T09:00:00'),
@@ -133,13 +133,13 @@ describe('ScheduleCreationPopup private schedule', function() {
         togglePrivateButton();
         clickSaveButton();
 
-        result = spy.calls.argsFor(0)[0];
+        creationEventData = spy.calls.argsFor(0)[0];
 
-        expect(result.isPrivate).toBe(true);
+        expect(creationEventData.isPrivate).toBe(true);
     });
 
     it('should be able to update public schedule to private schedule', function() {
-        var result;
+        var updateEventData;
         var mockEditModeViewModel = {
             schedule: {
                 id: '1',
@@ -156,12 +156,13 @@ describe('ScheduleCreationPopup private schedule', function() {
         togglePrivateButton();
         clickSaveButton();
 
-        result = spy.calls.argsFor(0)[0];
+        updateEventData = spy.calls.argsFor(0)[0];
 
-        expect(result.changes.isPrivate).toBe(true);
+        expect(updateEventData.changes.isPrivate).toBe(true);
     });
 
     it('should render private status activated when editing private schedule', function() {
+        var isPrivateEnabled;
         var mockEditModeViewModel = {
             schedule: {
                 id: '1',
@@ -174,7 +175,8 @@ describe('ScheduleCreationPopup private schedule', function() {
         };
         popup.render(mockEditModeViewModel);
 
-        expect(getPrivateButton().classList.contains('tui-full-calendar-public')).toBe(false);
+        isPrivateEnabled = !getPrivateButton().classList.contains('tui-full-calendar-public');
+        expect(isPrivateEnabled).toBe(true);
     });
 });
 

--- a/test/app/view/scheduleCreationPopup.spec.js
+++ b/test/app/view/scheduleCreationPopup.spec.js
@@ -136,7 +136,6 @@ describe('ScheduleCreationPopup private schedule', function() {
         result = spy.calls.argsFor(0)[0];
 
         expect(result.isPrivate).toBe(true);
-        expect(spy.calls.any()).toBe(true);
     });
 
     it('should be able to update public schedule to private schedule', function() {

--- a/test/app/view/scheduleCreationPopup.spec.js
+++ b/test/app/view/scheduleCreationPopup.spec.js
@@ -13,13 +13,13 @@ describe('ScheduleCreationPopup date range picker', function() {
     var startPickerId = 'tui-full-calendar-schedule-start-date';
     var endPickerId = 'tui-full-calendar-schedule-end-date';
     var mockTimedViewModel = {
-        start: '2015-05-01T09:00:00',
-        end: '2015-05-01T10:00:00',
+        start: new TZDate('2015-05-01T09:00:00'),
+        end: new TZDate('2015-05-01T10:00:00'),
         guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
     };
     var mockAllDayViewModel = {
-        start: '2015-05-01T09:00:00',
-        end: '2015-05-01T10:00:00',
+        start: new TZDate('2015-05-01T09:00:00'),
+        end: new TZDate('2015-05-01T10:00:00'),
         isAllDay: true,
         guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
     };
@@ -91,26 +91,17 @@ describe('ScheduleCreationPopup date range picker', function() {
     });
 });
 
-describe('ScheduleCreationPopup private schedule', function() {
+fdescribe('ScheduleCreationPopup private schedule', function() {
     var container, popup;
-    var mockViewModel = {
-        title: 'mock schedule',
-        start: '2015-05-01T09:00:00',
-        end: '2015-05-01T10:00:00',
-        guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
-    };
-    var clickEvent = new MouseEvent('click', {bubbles: true});
 
     function togglePrivateButton() {
         var privateButton = document.getElementById('tui-full-calendar-schedule-private');
-
-        privateButton.dispatchEvent(clickEvent);
+        privateButton.click();
     }
 
     function clickSaveButton() {
         var saveButton = document.querySelector('.tui-full-calendar-popup-save');
-
-        saveButton.dispatchEvent(clickEvent);
+        saveButton.click();
     }
 
     beforeEach(function() {
@@ -126,6 +117,12 @@ describe('ScheduleCreationPopup private schedule', function() {
 
     it('should be able to create private schedule', function() {
         var result;
+        var mockViewModel = {
+            title: 'mock schedule',
+            start: new TZDate('2015-05-01T09:00:00'),
+            end: new TZDate('2015-05-01T10:00:00'),
+            guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
+        };
         var spy = jasmine.createSpy('beforeCreateSchedule');
         popup.on('beforeCreateSchedule', spy);
         popup.render(mockViewModel);
@@ -136,6 +133,30 @@ describe('ScheduleCreationPopup private schedule', function() {
         result = spy.calls.argsFor(0)[0];
 
         expect(result.isPrivate).toBe(true);
+        expect(spy.calls.any()).toBe(true);
+    });
+
+    it('should be able to update public schedule to private schedule', function() {
+        var result;
+        var mockEditModeViewModel = {
+            schedule: {
+                id: '1',
+                title: 'mock schedule',
+                start: new TZDate('2015-05-01T09:00:00'),
+                end: new TZDate('2015-05-01T10:00:00'),
+                guide: jasmine.createSpyObj('guide', ['clearGuideElement'])
+            }
+        };
+        var spy = jasmine.createSpy('beforeUpdateSchedule');
+        popup.on('beforeUpdateSchedule', spy);
+        popup.render(mockEditModeViewModel);
+
+        togglePrivateButton();
+        clickSaveButton();
+
+        result = spy.calls.argsFor(0)[0];
+
+        expect(result.changes.isPrivate).toBe(true);
     });
 });
 

--- a/test/app/view/scheduleCreationPopup.spec.js
+++ b/test/app/view/scheduleCreationPopup.spec.js
@@ -91,12 +91,15 @@ describe('ScheduleCreationPopup date range picker', function() {
     });
 });
 
-fdescribe('ScheduleCreationPopup private schedule', function() {
+describe('ScheduleCreationPopup private schedule', function() {
     var container, popup;
 
+    function getPrivateButton() {
+        return document.getElementById('tui-full-calendar-schedule-private');
+    }
+
     function togglePrivateButton() {
-        var privateButton = document.getElementById('tui-full-calendar-schedule-private');
-        privateButton.click();
+        getPrivateButton().click();
     }
 
     function clickSaveButton() {
@@ -157,6 +160,22 @@ fdescribe('ScheduleCreationPopup private schedule', function() {
         result = spy.calls.argsFor(0)[0];
 
         expect(result.changes.isPrivate).toBe(true);
+    });
+
+    it('should render private status activated when editing private schedule', function() {
+        var mockEditModeViewModel = {
+            schedule: {
+                id: '1',
+                title: 'mock schedule',
+                start: new TZDate('2015-05-01T09:00:00'),
+                end: new TZDate('2015-05-01T10:00:00'),
+                guide: jasmine.createSpyObj('guide', ['clearGuideElement']),
+                isPrivate: true
+            }
+        };
+        popup.render(mockEditModeViewModel);
+
+        expect(getPrivateButton().classList.contains('tui-full-calendar-public')).toBe(false);
     });
 });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Changed wrong JSDoc comment (#930)
- Fixed wrong usage of the `raw` property in the `Schedule` model. (#927)
  - The `raw` property is only for library consumers who want to save arbitrary data in the `Schedule` instance.
  - There is already `isPrivate` in the `Schedule` model. so replace logic to use it.
  - Also example code has been changed not to use `raw` properties inappropriately.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
