### PR TITLE
feat: show 'see more events' popup in month view

### DIFF
--- a/apps/calendar/playwright/configs.ts
+++ b/apps/calendar/playwright/configs.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-process-env
 const PORT = process.env.CI ? 8080 : 6006;
 
-export const WEEK_VIEW_PAGE_URL = `http://localhost:${PORT}/iframe.html?id=weekview--fixed-events&args=&viewMode=story`;
+export const WEEK_VIEW_PAGE_URL = `http://localhost:${PORT}/iframe.html?id=views-weekview--fixed-events&args=&viewMode=story`;
 
-export const MONTH_VIEW_PAGE_URL = `http://localhost:${PORT}/iframe.html?id=monthview--fixed-events&args=&viewMode=story`;
+export const MONTH_VIEW_PAGE_URL = `http://localhost:${PORT}/iframe.html?id=views-monthview--fixed-events&args=&viewMode=story`;

--- a/apps/calendar/playwright/month/basic.spec.ts
+++ b/apps/calendar/playwright/month/basic.spec.ts
@@ -7,7 +7,8 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('basic test', async ({ page }) => {
-  const events = await page.$$('.toastui-calendar-weekday-event');
+  const eventsLocator = page.locator('.toastui-calendar-weekday-event');
+  const eventsCount = await eventsLocator.count();
 
-  expect(events).toHaveLength(4);
+  expect(eventsCount).toBe(5);
 });

--- a/apps/calendar/playwright/month/seeMoreEventsPopup.spec.ts
+++ b/apps/calendar/playwright/month/seeMoreEventsPopup.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+import { MONTH_VIEW_PAGE_URL } from '../configs';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(MONTH_VIEW_PAGE_URL);
+});
+
+test.describe('more events popup', () => {
+  test('when clicking on "more events" button, popup should be visible', async ({ page }) => {
+    await page.click('text=/\\d+ more/i >> nth=0');
+
+    const popupLocator = page.locator('css=[role=dialog]');
+    expect(await popupLocator.isVisible()).toBe(true);
+
+    const listLocator = popupLocator.locator('css=[class*=list]');
+    const listItemCount = await listLocator.evaluate((list) => list.children.length);
+
+    expect(listItemCount).toBeGreaterThan(0);
+  });
+});

--- a/apps/calendar/src/components/dayGridMonth/cellHeader.tsx
+++ b/apps/calendar/src/components/dayGridMonth/cellHeader.tsx
@@ -44,7 +44,7 @@ const CellHeader: FunctionComponent<Props> = ({
       {exceedCount ? (
         <MoreEventsButton
           number={exceedCount}
-          clickHandler={onClickExceedCount}
+          onClickButton={onClickExceedCount}
           className={cls('grid-cell-more-events')}
         />
       ) : null}

--- a/apps/calendar/src/components/dayGridMonth/dayGridMonth.tsx
+++ b/apps/calendar/src/components/dayGridMonth/dayGridMonth.tsx
@@ -35,7 +35,6 @@ interface Props {
   options: CalendarMonthOptions;
   dateMatrix: TZDate[][];
   gridInfo: GridInfo[];
-  appContainer: RefObject<HTMLDivElement>;
   events?: EventModel[];
 }
 
@@ -113,7 +112,6 @@ export const DayGridMonth: FunctionComponent<Props> = ({
   options,
   dateMatrix = [],
   gridInfo = [],
-  appContainer,
 }) => {
   const [gridContainer, setGridContainerRef] = useDOMNode<HTMLDivElement>();
   const calendarData = useStore(calendarSelector);
@@ -169,7 +167,6 @@ export const DayGridMonth: FunctionComponent<Props> = ({
                 gridDateEventModelMap={gridDateEventModelMap}
                 week={week}
                 gridInfo={gridInfo}
-                appContainer={appContainer}
                 height={height}
               />
               <MonthEvents

--- a/apps/calendar/src/components/dayGridMonth/dayGridMonth.tsx
+++ b/apps/calendar/src/components/dayGridMonth/dayGridMonth.tsx
@@ -144,11 +144,7 @@ export const DayGridMonth: FunctionComponent<Props> = ({
   );
 
   return (
-    <div
-      ref={setGridContainerRef}
-      onMouseDown={onMouseDown}
-      className={cls('month-daygrid__container')}
-    >
+    <div ref={setGridContainerRef} onMouseDown={onMouseDown} className={cls('month-daygrid')}>
       {dateMatrix.map((week, rowIndex) => {
         const { uiModels, gridDateEventModelMap } = renderedEventUiModels[rowIndex];
         const isMouseInWeek = rowIndex === currentGridPos?.y;

--- a/apps/calendar/src/components/dayGridMonth/dayGridMonth.tsx
+++ b/apps/calendar/src/components/dayGridMonth/dayGridMonth.tsx
@@ -119,7 +119,7 @@ export const DayGridMonth: FunctionComponent<Props> = ({
   const calendarData = useStore(calendarSelector);
   const { ref, height } = useGridHeight();
 
-  const { visibleWeeksCount, workweek, startDayOfWeek, narrowWeekend } = options;
+  const { visibleWeeksCount, narrowWeekend } = options;
   const rowHeight =
     TOTAL_PERCENT_HEIGHT / Math.max(visibleWeeksCount === 0 ? 6 : visibleWeeksCount, 1);
 
@@ -167,10 +167,8 @@ export const DayGridMonth: FunctionComponent<Props> = ({
               <GridRow
                 cssHeight={toPercent(TOTAL_PERCENT_HEIGHT)}
                 gridDateEventModelMap={gridDateEventModelMap}
-                workweek={workweek}
-                startDayOfWeek={startDayOfWeek}
-                narrowWeekend={narrowWeekend}
                 week={week}
+                gridInfo={gridInfo}
                 appContainer={appContainer}
                 height={height}
               />

--- a/apps/calendar/src/components/dayGridMonth/gridRow.tsx
+++ b/apps/calendar/src/components/dayGridMonth/gridRow.tsx
@@ -6,36 +6,23 @@ import { GridCell } from '@src/components/dayGridMonth/gridCell';
 import { useTheme } from '@src/contexts/theme';
 import { cls, toPercent } from '@src/helpers/css';
 import EventUIModel from '@src/model/eventUIModel';
-import { getGridInfo, toFormat, toStartOfDay } from '@src/time/datetime';
+import { toFormat, toStartOfDay } from '@src/time/datetime';
 
 import { Cells } from '@t/panel';
 
 interface Props {
   cssHeight?: CSSValue;
   gridDateEventModelMap?: Record<string, EventUIModel[]>;
-  narrowWeekend?: boolean;
-  startDayOfWeek?: number;
-  workweek?: boolean;
   week: Cells;
+  gridInfo: GridInfo[];
   appContainer: RefObject<HTMLDivElement>;
   height?: number;
 }
 
 export const GridRow: FunctionComponent<Props> = memo(
-  ({
-    cssHeight,
-    narrowWeekend = false,
-    startDayOfWeek = 0,
-    workweek = false,
-    week,
-    appContainer,
-    gridDateEventModelMap = {},
-    height = 0,
-  }) => {
+  ({ cssHeight, week, gridInfo, appContainer, gridDateEventModelMap = {}, height = 0 }) => {
     const container = useRef<HTMLDivElement>(null);
     const { common } = useTheme();
-
-    const { gridInfo } = getGridInfo(week.length, narrowWeekend, startDayOfWeek, workweek);
 
     return (
       <div

--- a/apps/calendar/src/components/dayGridMonth/gridRow.tsx
+++ b/apps/calendar/src/components/dayGridMonth/gridRow.tsx
@@ -15,12 +15,11 @@ interface Props {
   gridDateEventModelMap?: Record<string, EventUIModel[]>;
   week: Cells;
   gridInfo: GridInfo[];
-  appContainer: RefObject<HTMLDivElement>;
   height?: number;
 }
 
 export const GridRow: FunctionComponent<Props> = memo(
-  ({ cssHeight, week, gridInfo, appContainer, gridDateEventModelMap = {}, height = 0 }) => {
+  ({ cssHeight, week, gridInfo, gridDateEventModelMap = {}, height = 0 }) => {
     const container = useRef<HTMLDivElement>(null);
     const { common } = useTheme();
 
@@ -49,7 +48,6 @@ export const GridRow: FunctionComponent<Props> = memo(
                 left: toPercent(left),
               }}
               parentContainer={container.current}
-              appContainer={appContainer.current}
               events={gridDateEventModelMap[ymd]}
               height={height}
             />

--- a/apps/calendar/src/components/dayGridMonth/moreEventsButton.tsx
+++ b/apps/calendar/src/components/dayGridMonth/moreEventsButton.tsx
@@ -12,15 +12,18 @@ interface Props {
 const MoreEventsButton: FunctionComponent<Props> = ({ number, onClickButton, className }) => {
   const { reset } = useDispatch('dnd');
 
-  const handleClick = (e: MouseEvent) => {
+  const handleMouseDown = (e: MouseEvent) => {
     e.stopPropagation();
+  };
+
+  const handleClick = () => {
     reset();
     onClickButton();
   };
 
   return (
     // NOTE: use `onMouseDown` event to prevent `useDrag` from firing
-    <button type="button" onMouseDown={handleClick} className={className}>
+    <button type="button" onMouseDown={handleMouseDown} onClick={handleClick} className={className}>
       <Template template="monthGridHeaderExceed" model={number} />
     </button>
   );

--- a/apps/calendar/src/components/dayGridMonth/moreEventsButton.tsx
+++ b/apps/calendar/src/components/dayGridMonth/moreEventsButton.tsx
@@ -1,20 +1,26 @@
 import { FunctionComponent, h } from 'preact';
 
 import Template from '@src/components/template';
+import { useDispatch } from '@src/contexts/calendarStore';
 
 interface Props {
   number: number;
-  clickHandler: () => void;
+  onClickButton: () => void;
   className: string;
 }
 
-const MoreEventsButton: FunctionComponent<Props> = ({ number, clickHandler, className }) => {
-  if (!number) {
-    return null;
-  }
+const MoreEventsButton: FunctionComponent<Props> = ({ number, onClickButton, className }) => {
+  const { reset } = useDispatch('dnd');
+
+  const handleClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    reset();
+    onClickButton();
+  };
 
   return (
-    <button type="button" onClick={clickHandler} className={className}>
+    // NOTE: use `onMouseDown` event to prevent `useDrag` from firing
+    <button type="button" onMouseDown={handleClick} className={className}>
       <Template template="monthGridHeaderExceed" model={number} />
     </button>
   );

--- a/apps/calendar/src/components/floatingLayer.tsx
+++ b/apps/calendar/src/components/floatingLayer.tsx
@@ -7,6 +7,7 @@ import { useStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
 import { popupSelector } from '@src/selectors';
 import { PopupType } from '@src/slices/popup';
+import { isNil } from '@src/utils/type';
 
 import {
   EventDetailPopupParam,
@@ -32,7 +33,7 @@ const FloatingLayer: FunctionComponent = () => {
   const popupState = useStore(popupSelector);
   const { type, param } = popupState;
 
-  if (!type || !param) {
+  if (isNil(type) || isNil(param)) {
     return null;
   }
 

--- a/apps/calendar/src/components/layout.tsx
+++ b/apps/calendar/src/components/layout.tsx
@@ -82,5 +82,3 @@ export const Layout: FunctionComponent<Props> = ({
     </LayoutContainerRefProvider>
   );
 };
-
-Layout.displayName = 'Layout';

--- a/apps/calendar/src/components/layout.tsx
+++ b/apps/calendar/src/components/layout.tsx
@@ -57,7 +57,7 @@ export const Layout: FunctionComponent<Props> = ({
     }
 
     return noop;
-  }, [containerRef, updateLayoutHeight]);
+  }, [updateLayoutHeight]);
 
   useLayoutEffect(() => {
     if (autoAdjustPanels) {

--- a/apps/calendar/src/components/layout.tsx
+++ b/apps/calendar/src/components/layout.tsx
@@ -1,9 +1,12 @@
-import { ComponentProps, FunctionComponent, h, toChildArray } from 'preact';
-import { useLayoutEffect, useMemo, useRef } from 'preact/hooks';
+import { ComponentChildren, ComponentProps, h, toChildArray } from 'preact';
+import { forwardRef } from 'preact/compat';
+import { useLayoutEffect, useMemo } from 'preact/hooks';
 
 import { Panel } from '@src/components/panel';
 import { useDispatch } from '@src/contexts/calendarStore';
+import { LayoutContainerRefProvider } from '@src/contexts/layoutContainerRef';
 import { cls, toPercent } from '@src/helpers/css';
+import { useMergedRef } from '@src/hooks/common/mergedRef';
 import { noop } from '@src/utils/noop';
 import { isNil, isNumber, isString } from '@src/utils/type';
 
@@ -13,6 +16,7 @@ interface Props {
   height?: number;
   width?: number;
   className?: string;
+  children: ComponentChildren;
 }
 
 function getLayoutStylesFromInfo(width?: number, height?: number) {
@@ -29,39 +33,49 @@ function getLayoutStylesFromInfo(width?: number, height?: number) {
 }
 
 // @TODO: consider `direction` and `resizeMode`
-export const Layout: FunctionComponent<Props> = ({ children, width, height, className = '' }) => {
-  const layoutRef = useRef<HTMLDivElement>(null);
-  const { setLastPanelType, updateLayoutHeight } = useDispatch('weekViewLayout');
+export const Layout = forwardRef<HTMLDivElement, Props>(
+  ({ children, width, height, className = '' }, forwardedRef) => {
+    const containerRef = useMergedRef<HTMLDivElement>(forwardedRef);
+    const { setLastPanelType, updateLayoutHeight } = useDispatch('weekViewLayout');
 
-  const layoutClassName = useMemo(() => `${cls('layout')} ${className}`, [className]);
+    const layoutClassName = useMemo(() => `${cls('layout')} ${className}`, [className]);
 
-  useLayoutEffect(() => {
-    const layoutElement = layoutRef.current;
+    useLayoutEffect(() => {
+      const layoutElement = containerRef.current;
 
-    if (layoutElement) {
-      const onResizeWindow = () => updateLayoutHeight(layoutElement.offsetHeight);
+      if (layoutElement) {
+        const onResizeWindow = () => updateLayoutHeight(layoutElement.offsetHeight);
 
-      onResizeWindow();
-      window.addEventListener('resize', onResizeWindow);
+        onResizeWindow();
+        window.addEventListener('resize', onResizeWindow);
 
-      return () => window.removeEventListener('resize', onResizeWindow);
-    }
+        return () => window.removeEventListener('resize', onResizeWindow);
+      }
 
-    return noop;
-  }, [updateLayoutHeight]);
+      return noop;
+    }, [containerRef, updateLayoutHeight]);
 
-  useLayoutEffect(() => {
-    const childArray = toChildArray(children);
-    const lastChild = childArray[childArray.length - 1];
+    useLayoutEffect(() => {
+      const childArray = toChildArray(children);
+      const lastChild = childArray[childArray.length - 1];
 
-    if (!isString(lastChild) && !isNumber(lastChild) && !isNil(lastChild)) {
-      setLastPanelType((lastChild.props as unknown as ComponentProps<typeof Panel>).name);
-    }
-  }, [children, setLastPanelType]);
+      if (!isString(lastChild) && !isNumber(lastChild) && !isNil(lastChild)) {
+        setLastPanelType((lastChild.props as unknown as ComponentProps<typeof Panel>).name);
+      }
+    }, [children, setLastPanelType]);
 
-  return (
-    <div ref={layoutRef} className={layoutClassName} style={getLayoutStylesFromInfo(width, height)}>
-      {children}
-    </div>
-  );
-};
+    return (
+      <LayoutContainerRefProvider value={containerRef}>
+        <div
+          ref={containerRef}
+          className={layoutClassName}
+          style={getLayoutStylesFromInfo(width, height)}
+        >
+          {children}
+        </div>
+      </LayoutContainerRefProvider>
+    );
+  }
+);
+
+Layout.displayName = 'Layout';

--- a/apps/calendar/src/components/popup/seeMoreEventsPopup.tsx
+++ b/apps/calendar/src/components/popup/seeMoreEventsPopup.tsx
@@ -33,7 +33,11 @@ export const SeeMoreEventsPopup: FunctionComponent<SeeMorePopupParam> = ({ date,
   };
 
   return (
-    <div className={cls('see-more')} style={{ ...moreView, padding: MONTH_MORE_VIEW_PADDING }}>
+    <div
+      role="dialog"
+      className={cls('see-more')}
+      style={{ ...moreView, padding: MONTH_MORE_VIEW_PADDING }}
+    >
       <div className={cls('see-more-header')} style={style}>
         <Template template="monthMoreTitleDate" model={moreTitle} />
         <ClosePopupButton />

--- a/apps/calendar/src/components/ui/button.tsx
+++ b/apps/calendar/src/components/ui/button.tsx
@@ -1,18 +1,11 @@
-import { FunctionComponent, h } from 'preact';
+import { FunctionComponent, h, JSX } from 'preact';
 
-interface Props {
-  name: string;
-  value: string;
-  className: string;
-  onClick: (value: string) => void;
-}
+type Props = JSX.HTMLAttributes<HTMLButtonElement>;
 
-const Button: FunctionComponent<Props> = ({ name, onClick, value, className }) => {
+export const Button: FunctionComponent<Props> = ({ children, ...rest }) => {
   return (
-    <button type="button" className={className} onClick={() => onClick(value)}>
-      {name}
+    <button {...rest} type="button">
+      {children}
     </button>
   );
 };
-
-export default Button;

--- a/apps/calendar/src/components/view/month.tsx
+++ b/apps/calendar/src/components/view/month.tsx
@@ -1,20 +1,16 @@
 import { FunctionComponent, h } from 'preact';
-import { useLayoutEffect, useMemo, useState } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 
 import GridHeader from '@src/components/dayGridCommon/gridHeader';
 import { DayGridMonth } from '@src/components/dayGridMonth/dayGridMonth';
 import { Layout } from '@src/components/layout';
-import { Panel } from '@src/components/panel';
-import { MONTH_DAY_NAME_HEIGHT } from '@src/constants/style';
 import { useStore } from '@src/contexts/calendarStore';
 import { useTheme } from '@src/contexts/theme';
 import { cls } from '@src/helpers/css';
 import { capitalizeDayName } from '@src/helpers/dayName';
 import { createDateMatrixOfMonth } from '@src/helpers/grid';
-import { useDOMNode } from '@src/hooks/common/domNode';
 import { optionsSelector } from '@src/selectors';
 import { getGridInfo, isWeekend } from '@src/time/datetime';
-import { getSize } from '@src/utils/dom';
 
 import { MonthOptions } from '@t/options';
 import { CalendarStore } from '@t/store';
@@ -36,27 +32,9 @@ function getDayNames(options: CalendarStore['options']) {
   return dayNames;
 }
 
-function useContainerHeight(container: HTMLDivElement | null, dayNameHeight: number) {
-  const [gridPanelHeight, setGridPanelHeight] = useState(0);
-
-  useLayoutEffect(() => {
-    if (container) {
-      const { height } = getSize(container);
-
-      setGridPanelHeight(height - dayNameHeight);
-    }
-  }, [container, dayNameHeight]);
-
-  return gridPanelHeight;
-}
-
 export const Month: FunctionComponent = () => {
-  const [container, containerRef] = useDOMNode<HTMLDivElement>();
-
   const options = useStore(optionsSelector);
   const theme = useTheme();
-
-  const gridPanelHeight = useContainerHeight(container, MONTH_DAY_NAME_HEIGHT);
 
   const dayNames = getDayNames(options);
   const monthOptions = options.month as Required<MonthOptions>;
@@ -73,20 +51,16 @@ export const Month: FunctionComponent = () => {
   );
 
   return (
-    <Layout className={cls('month')} ref={containerRef}>
-      <Panel name="month-daynames" initialHeight={MONTH_DAY_NAME_HEIGHT}>
-        <GridHeader
-          templateType="monthDayname"
-          dayNames={dayNames}
-          theme={theme.month.dayname}
-          options={monthOptions}
-          gridInfo={gridInfo}
-          type="month"
-        />
-      </Panel>
-      <Panel name="month-daygrid" initialHeight={gridPanelHeight}>
-        <DayGridMonth options={monthOptions} dateMatrix={dateMatrix} gridInfo={gridInfo} />
-      </Panel>
+    <Layout className={cls('month')}>
+      <GridHeader
+        templateType="monthDayname"
+        dayNames={dayNames}
+        theme={theme.month.dayname}
+        options={monthOptions}
+        gridInfo={gridInfo}
+        type="month"
+      />
+      <DayGridMonth options={monthOptions} dateMatrix={dateMatrix} gridInfo={gridInfo} />
     </Layout>
   );
 };

--- a/apps/calendar/src/components/view/month.tsx
+++ b/apps/calendar/src/components/view/month.tsx
@@ -1,8 +1,9 @@
-import { FunctionComponent, h, RefObject } from 'preact';
-import { useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { FunctionComponent, h } from 'preact';
+import { useLayoutEffect, useMemo, useState } from 'preact/hooks';
 
 import GridHeader from '@src/components/dayGridCommon/gridHeader';
 import { DayGridMonth } from '@src/components/dayGridMonth/dayGridMonth';
+import { Layout } from '@src/components/layout';
 import { Panel } from '@src/components/panel';
 import { MONTH_DAY_NAME_HEIGHT } from '@src/constants/style';
 import { useStore } from '@src/contexts/calendarStore';
@@ -10,6 +11,7 @@ import { useTheme } from '@src/contexts/theme';
 import { cls } from '@src/helpers/css';
 import { capitalizeDayName } from '@src/helpers/dayName';
 import { createDateMatrixOfMonth } from '@src/helpers/grid';
+import { useDOMNode } from '@src/hooks/common/domNode';
 import { optionsSelector } from '@src/selectors';
 import { getGridInfo, isWeekend } from '@src/time/datetime';
 import { getSize } from '@src/utils/dom';
@@ -34,12 +36,12 @@ function getDayNames(options: CalendarStore['options']) {
   return dayNames;
 }
 
-function useContainerHeight(container: RefObject<HTMLDivElement>, dayNameHeight: number) {
+function useContainerHeight(container: HTMLDivElement | null, dayNameHeight: number) {
   const [gridPanelHeight, setGridPanelHeight] = useState(0);
 
   useLayoutEffect(() => {
-    if (container.current) {
-      const { height } = getSize(container.current);
+    if (container) {
+      const { height } = getSize(container);
 
       setGridPanelHeight(height - dayNameHeight);
     }
@@ -49,12 +51,12 @@ function useContainerHeight(container: RefObject<HTMLDivElement>, dayNameHeight:
 }
 
 export const Month: FunctionComponent = () => {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [container, containerRef] = useDOMNode<HTMLDivElement>();
 
   const options = useStore(optionsSelector);
   const theme = useTheme();
 
-  const gridPanelHeight = useContainerHeight(containerRef, MONTH_DAY_NAME_HEIGHT);
+  const gridPanelHeight = useContainerHeight(container, MONTH_DAY_NAME_HEIGHT);
 
   const dayNames = getDayNames(options);
   const monthOptions = options.month as Required<MonthOptions>;
@@ -71,8 +73,7 @@ export const Month: FunctionComponent = () => {
   );
 
   return (
-    // @TODO: change to layout component
-    <div className={cls('month')} ref={containerRef}>
+    <Layout className={cls('month')} ref={containerRef}>
       <Panel name="month-daynames" initialHeight={MONTH_DAY_NAME_HEIGHT}>
         <GridHeader
           templateType="monthDayname"
@@ -84,13 +85,8 @@ export const Month: FunctionComponent = () => {
         />
       </Panel>
       <Panel name="month-daygrid" initialHeight={gridPanelHeight}>
-        <DayGridMonth
-          options={monthOptions}
-          dateMatrix={dateMatrix}
-          gridInfo={gridInfo}
-          appContainer={containerRef}
-        />
+        <DayGridMonth options={monthOptions} dateMatrix={dateMatrix} gridInfo={gridInfo} />
       </Panel>
-    </div>
+    </Layout>
   );
 };

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -133,7 +133,7 @@ export const Week: FunctionComponent = () => {
     });
 
   return (
-    <Layout className={cls('week-view')}>
+    <Layout className={cls('week-view')} autoAdjustPanels={true}>
       <Panel name="week-view-daynames" initialHeight={WEEK_DAYNAME_HEIGHT + WEEK_DAYNAME_BORDER}>
         <GridHeader
           dayNames={dayNames}

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -6,6 +6,7 @@ import range from 'tui-code-snippet/array/range';
 import GridHeader from '@src/components/dayGridCommon/gridHeader';
 import { AlldayGridRow } from '@src/components/dayGridWeek/alldayGridRow';
 import { OtherGridRow } from '@src/components/dayGridWeek/otherGridRow';
+import { Layout } from '@src/components/layout';
 import { Panel } from '@src/components/panel';
 import { ColumnInfo } from '@src/components/timeGrid/columnWithMouse';
 import { TimeGrid } from '@src/components/timeGrid/timeGrid';
@@ -132,8 +133,7 @@ export const Week: FunctionComponent = () => {
     });
 
   return (
-    // @TODO: refactor Layout component
-    <div className={cls('week-view')}>
+    <Layout className={cls('week-view')}>
       <Panel name="week-view-daynames" initialHeight={WEEK_DAYNAME_HEIGHT + WEEK_DAYNAME_BORDER}>
         <GridHeader
           dayNames={dayNames}
@@ -148,6 +148,6 @@ export const Week: FunctionComponent = () => {
       <Panel name="time" autoSize={1}>
         <TimeGrid events={dayGridEvents.time} columnInfoList={columnInfoList} />
       </Panel>
-    </div>
+    </Layout>
   );
 };

--- a/apps/calendar/src/contexts/layoutContainerRef.tsx
+++ b/apps/calendar/src/contexts/layoutContainerRef.tsx
@@ -1,0 +1,18 @@
+import { createContext, RefObject } from 'preact';
+import { useContext } from 'preact/hooks';
+
+import { isUndefined } from '@src/utils/type';
+
+export const LayoutContainerRefContext = createContext<RefObject<HTMLDivElement> | null>(null);
+
+export const LayoutContainerRefProvider = LayoutContainerRefContext.Provider;
+
+export const useLayoutContainerRef = () => {
+  const ref = useContext(LayoutContainerRefContext);
+
+  if (isUndefined(ref)) {
+    throw new Error('LayoutContainerRefProvider is not found');
+  }
+
+  return ref;
+};

--- a/apps/calendar/src/css/daygrid/dayGrid.css
+++ b/apps/calendar/src/css/daygrid/dayGrid.css
@@ -48,6 +48,7 @@
   color: #aaa;
   border: none;
   background-color: transparent;
+  cursor: pointer;
 }
 
 .weekday-events {

--- a/apps/calendar/src/css/daygrid/dayGrid.css
+++ b/apps/calendar/src/css/daygrid/dayGrid.css
@@ -1,17 +1,20 @@
-.month {
+.layout.month {
   height: 100%;
+}
+
+.month .daynames {
+  /* from constant MONTH_DAY_NAME_HEIGHT */
+  height: 31px;
+}
+
+.month .month-daygrid {
+  position: relative;
+  /* modify this if you want to change height of daynames */
+  height: calc(100% - 31px);
 }
 
 .month-week-item {
   position: relative;
-}
-
-.month-daygrid {
-  position: relative;
-}
-
-.month-daygrid__container {
-  height: 100%;
 }
 
 .weekday-grid {

--- a/apps/calendar/src/css/daygrid/dayGrid.css
+++ b/apps/calendar/src/css/daygrid/dayGrid.css
@@ -10,7 +10,7 @@
   position: relative;
 }
 
-.month-daygrid .month-daygrid__container {
+.month-daygrid__container {
   height: 100%;
 }
 

--- a/apps/calendar/src/hooks/common/drag.ts
+++ b/apps/calendar/src/hooks/common/drag.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { useDispatch, useStore } from '@src/contexts/calendarStore';
+import { dndSelector } from '@src/selectors';
 import { DraggingState } from '@src/slices/dnd';
 import { isEscapePressed } from '@src/utils/keyboard';
 import { noop } from '@src/utils/noop';
 
 import { DraggingTypes } from '@t/drag';
-import { CalendarState } from '@t/store';
 
 export interface DragListeners {
   onDragStart?: MouseEventListener;
@@ -19,18 +19,17 @@ function isLeftClick(buttonNum: number) {
   return buttonNum === 0;
 }
 
-function isDraggingSelector(state: CalendarState) {
-  return state.dnd.draggingState > DraggingState.INIT;
-}
-
 export function useDrag(
   draggingItemType: DraggingTypes,
   { onDragStart = noop, onDrag = noop, onDragEnd = noop, onPressESCKey = noop }: DragListeners = {}
 ) {
   const { initDrag, setDraggingState, reset } = useDispatch('dnd');
 
-  const isDragging = useStore(isDraggingSelector);
+  const { draggingState, draggingItemType: currentDraggingItemType } = useStore(dndSelector);
   const [isStarted, setStarted] = useState(false);
+
+  const isDragging = draggingState > DraggingState.INIT;
+  const isRightItemType = currentDraggingItemType === draggingItemType;
 
   const onMouseMoveRef = useRef<MouseEventListener | null>(null);
   const onMouseUpRef = useRef<MouseEventListener | null>(null);
@@ -63,6 +62,12 @@ export function useDrag(
       // prevent text selection on dragging
       e.preventDefault();
 
+      if (!isRightItemType) {
+        setStarted(false);
+
+        return;
+      }
+
       if (!isDragging) {
         onDragStart(e);
         setDraggingState({ x: e.clientX, y: e.clientY });
@@ -73,7 +78,7 @@ export function useDrag(
       setDraggingState({ x: e.clientX, y: e.clientY });
       onDrag(e);
     },
-    [isDragging, onDrag, onDragStart, setDraggingState]
+    [isDragging, isRightItemType, onDrag, onDragStart, setDraggingState]
   );
 
   const onMouseUp = useCallback<MouseEventListener>(

--- a/apps/calendar/src/hooks/common/mergedRef.ts
+++ b/apps/calendar/src/hooks/common/mergedRef.ts
@@ -1,0 +1,27 @@
+import { Ref, RefObject } from 'preact';
+import { useMemo, useRef } from 'preact/hooks';
+
+export function useMergedRef<T>(...refs: Ref<T>[]): RefObject<T> {
+  const stableRef = useRef<T | null>(null);
+
+  return useMemo(
+    () => ({
+      get current() {
+        return stableRef.current;
+      },
+      set current(el) {
+        stableRef.current = el;
+        refs.forEach((ref) => {
+          if (ref) {
+            if (typeof ref === 'function') {
+              ref(el);
+            } else {
+              ref.current = el;
+            }
+          }
+        });
+      },
+    }),
+    [refs]
+  );
+}

--- a/apps/calendar/src/hooks/common/mergedRef.ts
+++ b/apps/calendar/src/hooks/common/mergedRef.ts
@@ -22,6 +22,7 @@ export function useMergedRef<T>(...refs: Ref<T>[]): RefObject<T> {
         });
       },
     }),
-    [refs]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refs
   );
 }

--- a/apps/calendar/src/hooks/dayGridCommon/dayGridSelection.ts
+++ b/apps/calendar/src/hooks/dayGridCommon/dayGridSelection.ts
@@ -10,12 +10,14 @@ import { isPresent } from '@src/utils/type';
 export function useDayGridSelection(
   mousePositionDataGrabber: MousePositionDataGrabber
 ): GridSelectionData | null {
+  const { draggingItemType, draggingState, x, y, initX, initY } = useStore(dndSelector);
+
   const [currentSelectionData, setCurrentSelectionData] = useState<CurrentGridSelectionData | null>(
     null
   );
   const initSelectionDataRef = useRef<InitGridSelectionData | null>(null);
   const prevSelectionDataRef = useRef<CurrentGridSelectionData | null>(null);
-  const { draggingItemType, draggingState, x, y, initX, initY } = useStore(dndSelector);
+
   const isSelectingGrid =
     draggingItemType === DRAGGING_TYPE_CONSTANTS.dayGridSelection &&
     draggingState >= DraggingState.INIT;

--- a/apps/calendar/stories/Button.tsx
+++ b/apps/calendar/stories/Button.tsx
@@ -1,9 +1,0 @@
-import { h, JSX, RenderableProps } from 'preact';
-
-const Button = ({ children, ...props }: RenderableProps<any>): JSX.Element => (
-  <button className="button" type="button" {...props}>
-    {children}
-  </button>
-);
-
-export default Button;

--- a/apps/calendar/stories/button.stories.tsx
+++ b/apps/calendar/stories/button.stories.tsx
@@ -1,8 +1,8 @@
-import { h, JSX } from 'preact';
+import { h } from 'preact';
 
-import Button from '@stories/Button';
+import { Button } from '@src/components/ui/button';
 
-export default { title: 'Button' };
+export default { title: 'Components/Button', component: Button };
 
-export const withText = (): JSX.Element => <Button>Text Button</Button>;
-export const withEmoji = (): JSX.Element => <Button>😀 😎 👍 💯</Button>;
+export const withText = () => <Button className="button">Text Button</Button>;
+export const withEmoji = () => <Button className="button">😀 😎 👍 💯</Button>;

--- a/apps/calendar/stories/columns.stories.tsx
+++ b/apps/calendar/stories/columns.stories.tsx
@@ -19,7 +19,7 @@ import { createEventModels } from '@stories/helper/event';
 import { TimeGridSelectionInfo } from '@t/components/timeGrid/gridSelection';
 import { EventModelData } from '@t/events';
 
-export default { title: 'Column' };
+export default { title: 'Components/Column', component: Column };
 
 interface WrapperProps {
   width: number;

--- a/apps/calendar/stories/dayGridMonth.stories.tsx
+++ b/apps/calendar/stories/dayGridMonth.stories.tsx
@@ -3,6 +3,7 @@ import { h } from 'preact';
 import { DayGridMonth } from '@src/components/dayGridMonth/dayGridMonth';
 import { GridCell } from '@src/components/dayGridMonth/gridCell';
 import { GridRow } from '@src/components/dayGridMonth/gridRow';
+import { Layout } from '@src/components/layout';
 import { createDateMatrixOfMonth } from '@src/helpers/grid';
 import TZDate from '@src/time/date';
 import { getGridInfo } from '@src/time/datetime';
@@ -19,12 +20,14 @@ export const Cell = () => {
 
   return (
     <ProviderWrapper>
-      <GridCell
-        date={date}
-        dayIndex={date.getDay()}
-        style={{ width: 100, height: 100 }}
-        height={100}
-      />
+      <Layout>
+        <GridCell
+          date={date}
+          dayIndex={date.getDay()}
+          style={{ width: 100, height: 100 }}
+          height={100}
+        />
+      </Layout>
     </ProviderWrapper>
   );
 };
@@ -36,12 +39,9 @@ export const Week = () => {
 
   return (
     <ProviderWrapper>
-      <GridRow
-        gridInfo={gridInfo}
-        cssHeight={100}
-        week={weekDates}
-        appContainer={{ current: document.createElement('div') }}
-      />
+      <Layout>
+        <GridRow gridInfo={gridInfo} cssHeight={100} week={weekDates} />
+      </Layout>
     </ProviderWrapper>
   );
 };
@@ -74,12 +74,9 @@ export const Month = () => {
 
   return (
     <ProviderWrapper>
-      <DayGridMonth
-        options={options}
-        dateMatrix={dateMatrix}
-        gridInfo={gridInfo}
-        appContainer={{ current: document.createElement('div') }}
-      />
+      <Layout>
+        <DayGridMonth options={options} dateMatrix={dateMatrix} gridInfo={gridInfo} />
+      </Layout>
     </ProviderWrapper>
   );
 };

--- a/apps/calendar/stories/dayGridMonth.stories.tsx
+++ b/apps/calendar/stories/dayGridMonth.stories.tsx
@@ -1,25 +1,20 @@
 import { h } from 'preact';
 
-import range from 'tui-code-snippet/array/range';
-
 import { DayGridMonth } from '@src/components/dayGridMonth/dayGridMonth';
 import { GridCell } from '@src/components/dayGridMonth/gridCell';
 import { GridRow } from '@src/components/dayGridMonth/gridRow';
-import { Panel } from '@src/components/panel';
-import EventModel from '@src/model/eventModel';
+import { createDateMatrixOfMonth } from '@src/helpers/grid';
 import TZDate from '@src/time/date';
 import { getGridInfo } from '@src/time/datetime';
 
-import { getWeekDates, getWeekendDates } from '@stories/util/mockCalendarDates';
+import { getWeekDates } from '@stories/util/mockCalendarDates';
 import { ProviderWrapper } from '@stories/util/providerWrapper';
-import { createRandomEvents } from '@stories/util/randomEvents';
 
-import { EventModelData } from '@t/events';
 import { CalendarMonthOptions } from '@t/store';
 
 export default { title: 'DayGridMonth' };
 
-export const cell = () => {
+export const Cell = () => {
   const date = new TZDate();
 
   return (
@@ -34,88 +29,26 @@ export const cell = () => {
   );
 };
 
-export const week = () => {
-  const calendar = getWeekDates();
-
-  return (
-    <ProviderWrapper>
-      <GridRow
-        cssHeight={100}
-        week={calendar}
-        appContainer={{ current: document.createElement('div') }}
-      />
-    </ProviderWrapper>
-  );
-};
-
-export const weekend = () => {
-  const calendar = getWeekendDates();
-
-  return (
-    <ProviderWrapper>
-      <GridRow
-        height={200}
-        week={calendar}
-        appContainer={{ current: document.createElement('div') }}
-      />
-    </ProviderWrapper>
-  );
-};
-
-export const daygrid = () => {
-  const date = new Date();
-
-  const dayIndex = date.getDay();
-  const start = date.getDate() - dayIndex;
-  const saturday = start + 6;
-  const sunday = saturday + 1;
-  const WEEKDAYS = 7;
-
-  const dateMatrix = range(3).map((index) => [
-    new TZDate(date.setDate(saturday + WEEKDAYS * index)),
-    new TZDate(date.setDate(sunday + WEEKDAYS * index)),
-  ]);
-
-  const options: CalendarMonthOptions = {
-    visibleWeeksCount: 3,
-    workweek: false,
-    narrowWeekend: true,
-    startDayOfWeek: 0,
-    isAlways6Week: true,
-    daynames: [],
-    moreLayerSize: { width: null, height: null },
-    grid: {
-      header: { height: 31 },
-      footer: { height: 31 },
-    },
-    visibleEventCount: 6,
-    eventFilter: () => true,
-  };
-
-  const { gridInfo } = getGridInfo(
-    options.daynames.length,
-    options.narrowWeekend,
-    options.startDayOfWeek,
-    options.workweek
-  );
-
-  return (
-    <ProviderWrapper>
-      <DayGridMonth
-        options={options}
-        dateMatrix={dateMatrix}
-        gridInfo={gridInfo}
-        appContainer={{ current: document.createElement('div') }}
-      />
-    </ProviderWrapper>
-  );
-};
-
-export const randomEvents = () => {
+export const Week = () => {
   const weekDates = getWeekDates();
 
+  const { gridInfo } = getGridInfo(weekDates.length, false, 0, false);
+
+  return (
+    <ProviderWrapper>
+      <GridRow
+        gridInfo={gridInfo}
+        cssHeight={100}
+        week={weekDates}
+        appContainer={{ current: document.createElement('div') }}
+      />
+    </ProviderWrapper>
+  );
+};
+
+export const Month = () => {
   const options: CalendarMonthOptions = {
-    visibleWeeksCount: 1,
+    visibleWeeksCount: 3,
     workweek: false,
     narrowWeekend: false,
     startDayOfWeek: 0,
@@ -130,27 +63,23 @@ export const randomEvents = () => {
     eventFilter: () => true,
   };
 
-  const data = createRandomEvents('month', weekDates[0], weekDates[6], 10);
-  const events = data.map((event: EventModelData) => EventModel.create(event));
+  const dateMatrix = createDateMatrixOfMonth(new Date(), options);
 
   const { gridInfo } = getGridInfo(
-    options.daynames.length,
+    dateMatrix[0].length,
     options.narrowWeekend,
     options.startDayOfWeek,
     options.workweek
   );
 
   return (
-    <ProviderWrapper events={events}>
-      <Panel name="weekday" initialHeight={400}>
-        <DayGridMonth
-          options={options}
-          dateMatrix={[weekDates]}
-          events={events}
-          gridInfo={gridInfo}
-          appContainer={{ current: document.createElement('div') }}
-        />
-      </Panel>
+    <ProviderWrapper>
+      <DayGridMonth
+        options={options}
+        dateMatrix={dateMatrix}
+        gridInfo={gridInfo}
+        appContainer={{ current: document.createElement('div') }}
+      />
     </ProviderWrapper>
   );
 };

--- a/apps/calendar/stories/dayGridMonth.stories.tsx
+++ b/apps/calendar/stories/dayGridMonth.stories.tsx
@@ -12,7 +12,7 @@ import { ProviderWrapper } from '@stories/util/providerWrapper';
 
 import { CalendarMonthOptions } from '@t/store';
 
-export default { title: 'DayGridMonth' };
+export default { title: 'Components/DayGridMonth', component: DayGridMonth };
 
 export const Cell = () => {
   const date = new TZDate();

--- a/apps/calendar/stories/dayView.stories.tsx
+++ b/apps/calendar/stories/dayView.stories.tsx
@@ -2,7 +2,6 @@ import { h } from 'preact';
 
 import { Story } from '@storybook/preact';
 
-import FloatingLayer from '@src/components/floatingLayer';
 import { Day } from '@src/components/view/day';
 import EventModel from '@src/model/eventModel';
 import TZDate from '@src/time/date';
@@ -24,7 +23,6 @@ function createTimeGridEvents() {
 const Template: Story = (args) => (
   <ProviderWrapper options={args.options} events={args.events}>
     <Day />
-    <FloatingLayer />
   </ProviderWrapper>
 );
 

--- a/apps/calendar/stories/dayView.stories.tsx
+++ b/apps/calendar/stories/dayView.stories.tsx
@@ -11,7 +11,7 @@ import { addDate } from '@src/time/datetime';
 import { ProviderWrapper } from '@stories/util/providerWrapper';
 import { createRandomEventModelsForMonth, createRandomEvents } from '@stories/util/randomEvents';
 
-export default { title: 'DayView' };
+export default { title: 'Views/DayView', component: Day };
 
 function createTimeGridEvents() {
   const today = new TZDate();

--- a/apps/calendar/stories/eventDetailPopup.stories.tsx
+++ b/apps/calendar/stories/eventDetailPopup.stories.tsx
@@ -12,7 +12,7 @@ import { EventDetailPopupParam } from '@t/store';
 
 export default {
   component: EventDetailPopup,
-  title: 'Popup/EventDetailPopup',
+  title: 'Popups/EventDetailPopup',
 };
 
 const Template: Story<EventDetailPopupParam> = (args) => (

--- a/apps/calendar/stories/eventFormPopup.stories.tsx
+++ b/apps/calendar/stories/eventFormPopup.stories.tsx
@@ -13,7 +13,7 @@ import { EventFormPopupParam } from '@t/store';
 
 export default {
   component: EventFormPopup,
-  title: 'Popup/EventFormPopup',
+  title: 'Popups/EventFormPopup',
 };
 
 interface EventFormPopupStoryProps extends EventFormPopupParam {

--- a/apps/calendar/stories/events.stories.tsx
+++ b/apps/calendar/stories/events.stories.tsx
@@ -7,7 +7,7 @@ import EventUIModel from '@src/model/eventUIModel';
 
 import { ProviderWrapper } from '@stories/util/providerWrapper';
 
-export default { title: 'Various Event Blocks' };
+export default { title: 'Components/EventBlocks' };
 
 export const timeEvent = () => {
   const event = EventModel.create({

--- a/apps/calendar/stories/gridHeader.stories.tsx
+++ b/apps/calendar/stories/gridHeader.stories.tsx
@@ -9,7 +9,7 @@ import { ProviderWrapper } from '@stories/util/providerWrapper';
 
 import { TemplateMonthDayName } from '@t/template';
 
-export default { title: 'GridHeader' };
+export default { title: 'Components/GridHeader', component: GridHeader };
 
 interface DayNamesStory {
   dayNames: TemplateMonthDayName[];

--- a/apps/calendar/stories/gridRow.stories.tsx
+++ b/apps/calendar/stories/gridRow.stories.tsx
@@ -16,7 +16,11 @@ import { createRandomEventModelsForMonth } from '@stories/util/randomEvents';
 
 import { CalendarData } from '@t/events';
 
-export default { title: 'GridRow', component: OtherGridRow, args: { primary: true } };
+export default {
+  title: 'Components/WeekGridRow',
+  component: OtherGridRow,
+  args: { primary: true },
+};
 
 const events = createRandomEventModelsForMonth(40);
 

--- a/apps/calendar/stories/layout.stories.tsx
+++ b/apps/calendar/stories/layout.stories.tsx
@@ -5,7 +5,7 @@ import { Panel } from '@src/components/panel';
 
 import { ProviderWrapper } from '@stories/util/providerWrapper';
 
-export default { title: 'Layout' };
+export default { title: 'Components/Layout', component: Layout };
 
 export const vertical = () => (
   <ProviderWrapper>

--- a/apps/calendar/stories/main.stories.tsx
+++ b/apps/calendar/stories/main.stories.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, h } from 'preact';
 import { Story } from '@storybook/preact';
 
 import FloatingLayer from '@src/components/floatingLayer';
+import { Button } from '@src/components/ui/button';
 import { Main } from '@src/components/view/main';
 import { useDispatch } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
@@ -10,7 +11,7 @@ import { cls } from '@src/helpers/css';
 import { ProviderWrapper } from '@stories/util/providerWrapper';
 import { createRandomEventModelsForMonth } from '@stories/util/randomEvents';
 
-export default { title: 'Main' };
+export default { title: 'Views/Main', component: Main };
 
 const style = {
   position: 'absolute',
@@ -33,9 +34,9 @@ const Toolbar = () => {
 
   return (
     <div>
-      <button onClick={() => changeView('month')}>Month</button>
-      <button onClick={() => changeView('week')}>Week</button>
-      <button onClick={() => changeView('day')}>Day</button>
+      <Button onClick={() => changeView('month')}>Month</Button>
+      <Button onClick={() => changeView('week')}>Week</Button>
+      <Button onClick={() => changeView('day')}>Day</Button>
     </div>
   );
 };

--- a/apps/calendar/stories/monthView.stories.tsx
+++ b/apps/calendar/stories/monthView.stories.tsx
@@ -12,7 +12,7 @@ import { createRandomEventModelsForMonth } from '@stories/util/randomEvents';
 
 import { EventModelData } from '@t/events';
 
-export default { title: 'MonthView' };
+export default { title: 'Views/MonthView', component: Month };
 
 function createMonthEvents() {
   const DAYS_OF_WEEK = 7;

--- a/apps/calendar/stories/monthView.stories.tsx
+++ b/apps/calendar/stories/monthView.stories.tsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 
 import { Story } from '@storybook/preact';
+import range from 'tui-code-snippet/array/range';
 
 import { Month } from '@src/components/view/month';
 import EventModel from '@src/model/eventModel';
@@ -53,6 +54,14 @@ function createMonthEvents() {
       id: '2',
     },
   ];
+  range(10).forEach((i) => {
+    events.push({
+      title: `event2-${i}`,
+      start: secondTuesday,
+      end: secondThursday,
+      id: `${i}${i}`,
+    });
+  });
 
   return events.map((event) => EventModel.create(event));
 }

--- a/apps/calendar/stories/timegrid.stories.tsx
+++ b/apps/calendar/stories/timegrid.stories.tsx
@@ -13,7 +13,7 @@ import { createRandomEvents } from '@stories/util/randomEvents';
 
 import { EventModelData } from '@t/events';
 
-export default { title: 'TimeGrid' };
+export default { title: 'Components/TimeGrid', component: TimeGrid };
 
 function toThisWeek(date: TZDate) {
   const today = toStartOfDay(new TZDate());

--- a/apps/calendar/stories/times.stories.tsx
+++ b/apps/calendar/stories/times.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 import { ProviderWrapper } from '@stories/util/providerWrapper';
 
-export default { title: 'Times' };
+export default { title: 'Components/Times', component: Times };
 
 export const minutesInAnHour = () => {
   const now = new TZDate();

--- a/apps/calendar/stories/util/providerWrapper.tsx
+++ b/apps/calendar/stories/util/providerWrapper.tsx
@@ -1,15 +1,13 @@
 import { h, RenderableProps } from 'preact';
 
 import { CalendarContainer } from '@src/calendarContainer';
-import { initCalendarStore, StoreProvider } from '@src/contexts/calendarStore';
-import { ThemeProvider } from '@src/contexts/theme';
-import { cls } from '@src/helpers/css';
+import { initCalendarStore } from '@src/contexts/calendarStore';
 import EventModel from '@src/model/eventModel';
 import Theme from '@src/theme';
 
 import { Options } from '@t/options';
 
-const style = {
+const rootContainerStyle = {
   position: 'absolute',
   left: 0,
   right: 0,
@@ -40,7 +38,7 @@ export function ProviderWrapper({
 
   return (
     <CalendarContainer theme={theme} store={store}>
-      {children}
+      <div style={rootContainerStyle}>{children}</div>
     </CalendarContainer>
   );
 }

--- a/apps/calendar/stories/util/providerWrapper.tsx
+++ b/apps/calendar/stories/util/providerWrapper.tsx
@@ -1,5 +1,6 @@
 import { h, RenderableProps } from 'preact';
 
+import { CalendarContainer } from '@src/calendarContainer';
 import { initCalendarStore, StoreProvider } from '@src/contexts/calendarStore';
 import { ThemeProvider } from '@src/contexts/theme';
 import { cls } from '@src/helpers/css';
@@ -38,10 +39,8 @@ export function ProviderWrapper({
   }
 
   return (
-    <ThemeProvider theme={theme}>
-      <div className={cls('layout')} style={style}>
-        <StoreProvider store={store}>{children}</StoreProvider>
-      </div>
-    </ThemeProvider>
+    <CalendarContainer theme={theme} store={store}>
+      {children}
+    </CalendarContainer>
   );
 }

--- a/apps/calendar/stories/util/providerWrapper.tsx
+++ b/apps/calendar/stories/util/providerWrapper.tsx
@@ -11,8 +11,8 @@ const rootContainerStyle = {
   position: 'absolute',
   left: 0,
   right: 0,
-  bottom: 5,
-  top: 5,
+  bottom: 0,
+  top: 0,
 };
 
 type Props = {

--- a/apps/calendar/stories/weekView.stories.tsx
+++ b/apps/calendar/stories/weekView.stories.tsx
@@ -13,7 +13,7 @@ import { createRandomEventModelsForMonth, createRandomEvents } from '@stories/ut
 
 import { EventModelData } from '@t/events';
 
-export default { title: 'WeekView' };
+export default { title: 'Views/WeekView', component: Week };
 
 function createTimeGridEvents() {
   const today = new TZDate();

--- a/apps/calendar/stories/weekView.stories.tsx
+++ b/apps/calendar/stories/weekView.stories.tsx
@@ -2,7 +2,6 @@ import { h } from 'preact';
 
 import { Story } from '@storybook/preact';
 
-import FloatingLayer from '@src/components/floatingLayer';
 import { Week } from '@src/components/view/week';
 import EventModel from '@src/model/eventModel';
 import TZDate from '@src/time/date';
@@ -65,7 +64,6 @@ function createWeekEvents() {
 const Template: Story = (args) => (
   <ProviderWrapper options={args.options} events={args.events}>
     <Week />
-    <FloatingLayer />
   </ProviderWrapper>
 );
 

--- a/apps/calendar/types/components/daygrid/cell.d.ts
+++ b/apps/calendar/types/components/daygrid/cell.d.ts
@@ -15,6 +15,6 @@ type SeeMoreOptions = {
 type SeeMoreRectParam = {
   cell: HTMLDivElement;
   grid: HTMLDivElement;
-  appContainer: HTMLDivElement;
+  layoutContainer: HTMLDivElement;
   popupSize: { width: number; height: number };
 };


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

https://user-images.githubusercontent.com/14539203/147737192-895d2a4f-837e-4783-b5a9-1d33389f097e.mov

- Added interaction when clicking the '`n` more' button in the month view.
  - It shows more events popup and minimized the conflict between the grid selection.
- Organized storybook structure.
- Applied `Layout` component.
  - Added a new context value to pass the container DOM ref to the descendant component.
- Removed redundant prop drilling in the month view.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
