### PR TITLE
fix: update timezones property when calling `setOptions` method (fix #967)

### DIFF
--- a/src/js/factory/calendar.js
+++ b/src/js/factory/calendar.js
@@ -1822,6 +1822,10 @@ Calendar.prototype.setOptions = function(options, silent) {
 
     this._setAdditionalInternalOptions(options);
 
+    if (util.isObject(options.timezone) && util.isArray(options.timezone.zones)) {
+        this._options.timezones = options.timezone.zones;
+    }
+
     if (!silent) {
         this.changeView(this._viewName, true);
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* `TimeGrid` relies on deprecated `timezones` property yet. So synchronize it.
* Reference: https://github.com/nhn/tui.calendar/blob/248131a10c333b2cbae89adc2e7f1c7db5a68cd1/src/js/factory/calendar.js#L726

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
