### PR TITLE
feat: implement week.eventView and week.taskView options

### DIFF
--- a/apps/calendar/index.d.ts
+++ b/apps/calendar/index.d.ts
@@ -145,6 +145,8 @@ export interface IWeekOptions {
   timezones?: TimezoneConfig[];
   hourStart?: number;
   hourEnd?: number;
+  eventView?: boolean | string[];
+  taskView?: boolean | string[];
 }
 
 export interface IMonthOptions {
@@ -234,8 +236,6 @@ export interface ITheme {
 
 export interface IOptions {
   defaultView?: string;
-  taskView?: boolean | string[];
-  eventView?: boolean | string[];
   theme?: ITheme;
   template?: ITemplateConfig;
   week?: IWeekOptions;

--- a/apps/calendar/playwright/day/timeGridEventMoving.e2e.ts
+++ b/apps/calendar/playwright/day/timeGridEventMoving.e2e.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import waitForExpect from 'wait-for-expect';
 
 import { addHours, setTimeStrToDate } from '../../src/time/datetime';
 import { mockDayViewEvents } from '../../stories/mocks/mockDayViewEvents';

--- a/apps/calendar/src/components/panel.tsx
+++ b/apps/calendar/src/components/panel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact';
 import { forwardRef } from 'preact/compat';
-import { useCallback, useLayoutEffect } from 'preact/hooks';
+import { useCallback, useLayoutEffect, useMemo } from 'preact/hooks';
 
 import { PanelResizer } from '@src/components/panelResizer';
 import { DEFAULT_RESIZER_LENGTH } from '@src/constants/layout';
@@ -115,20 +115,20 @@ export const Panel = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(functi
     maxWidth,
   });
 
-  const isResizable = (category: string) => {
+  const isResizable = useMemo(() => {
     if (isNil(resizable) || isBoolean(resizable)) {
       return !!resizable;
     }
 
-    return resizable.includes(category);
-  };
+    return resizable.includes(name);
+  }, [resizable, name]);
 
   return (
     <Fragment>
       <div className={cls('panel', name)} style={styles} ref={ref}>
         {children}
       </div>
-      {isResizable(name) ? (
+      {isResizable ? (
         <PanelResizer
           name={name as AlldayEventCategory}
           width={resizerWidth}

--- a/apps/calendar/src/components/panel.tsx
+++ b/apps/calendar/src/components/panel.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_RESIZER_LENGTH } from '@src/constants/layout';
 import { DEFAULT_PANEL_HEIGHT } from '@src/constants/style';
 import { useDispatch, useStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
+import { isBoolean, isNil } from '@src/utils/type';
 
 import type { PropsWithChildren, StyleProp } from '@t/components/common';
 import type { AlldayEventCategory } from '@t/panel';
@@ -29,7 +30,7 @@ interface Props {
   maxExpandableHeight?: number;
   maxExpandableWidth?: number;
 
-  resizable?: boolean;
+  resizable?: boolean | string[];
   resizerHeight?: number;
   resizerWidth?: number;
 }
@@ -114,18 +115,26 @@ export const Panel = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(functi
     maxWidth,
   });
 
+  const isResizable = (category: string) => {
+    if (isNil(resizable) || isBoolean(resizable)) {
+      return !!resizable;
+    }
+
+    return resizable.includes(category);
+  };
+
   return (
     <Fragment>
       <div className={cls('panel', name)} style={styles} ref={ref}>
         {children}
       </div>
-      {resizable && (
+      {isResizable(name) ? (
         <PanelResizer
           name={name as AlldayEventCategory}
           width={resizerWidth}
           height={resizerHeight}
         />
-      )}
+      ) : null}
     </Fragment>
   );
 });

--- a/apps/calendar/src/components/view/day.spec.tsx
+++ b/apps/calendar/src/components/view/day.spec.tsx
@@ -11,10 +11,7 @@ import type { WeekOptions } from '@t/options';
 
 describe('day', () => {
   function setup(weekOptions: WeekOptions) {
-    const store = initCalendarStore();
-    store.getState().dispatch.options.setOptions({
-      week: weekOptions,
-    });
+    const store = initCalendarStore({ week: weekOptions });
 
     return render(<Day />, { store });
   }

--- a/apps/calendar/src/components/view/day.spec.tsx
+++ b/apps/calendar/src/components/view/day.spec.tsx
@@ -1,0 +1,85 @@
+import { h } from 'preact';
+
+import { render } from '@testing-library/preact';
+
+import { Day } from '@src/components/view/day';
+import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
+import { initCalendarStore, StoreProvider } from '@src/contexts/calendarStore';
+import { EventBusProvider } from '@src/contexts/eventBus';
+import { initThemeStore, ThemeProvider } from '@src/contexts/themeStore';
+import { cls } from '@src/helpers/css';
+import { EventBusImpl } from '@src/utils/eventBus';
+import { isBoolean } from '@src/utils/type';
+
+import type { WeekOptions } from '@t/options';
+
+describe('day', () => {
+  function setup(weekOptions: WeekOptions) {
+    const eventBus = new EventBusImpl();
+    const store = initCalendarStore();
+    const theme = initThemeStore();
+
+    store.getState().dispatch.options.setOptions({
+      week: weekOptions,
+    });
+
+    return render(
+      <EventBusProvider value={eventBus}>
+        <ThemeProvider store={theme}>
+          <StoreProvider store={store}>
+            <Day />
+          </StoreProvider>
+        </ThemeProvider>
+      </EventBusProvider>
+    );
+  }
+
+  describe('eventView and taskView options', () => {
+    const cases: WeekOptions[] = [
+      { eventView: true, taskView: true },
+      { eventView: false, taskView: false },
+      { eventView: ['allday'], taskView: ['milestone'] },
+      { eventView: ['allday', 'time'], taskView: false },
+    ];
+
+    function getExpectedResult({ eventView, taskView }: WeekOptions) {
+      const result: {
+        milestone?: boolean;
+        task?: boolean;
+        allday?: boolean;
+        time?: boolean;
+      } = {};
+
+      DEFAULT_EVENT_PANEL.forEach((eventPanel) => {
+        result[eventPanel] = isBoolean(eventView) ? eventView : !!eventView?.includes(eventPanel);
+      });
+
+      DEFAULT_TASK_PANEL.forEach((taskPanel) => {
+        result[taskPanel] = isBoolean(taskView) ? taskView : !!taskView?.includes(taskPanel);
+      });
+
+      return result;
+    }
+
+    cases.forEach((weekOptions) => {
+      it(`show/hide the panels in the daily view: { eventView: ${weekOptions.eventView}, taskView: ${weekOptions.taskView} }`, () => {
+        // Given
+        const { container } = setup(weekOptions);
+
+        // When
+        // Nothing
+
+        // Then
+        const results = getExpectedResult(weekOptions);
+        for (const [name, result] of Object.entries(results)) {
+          const panel = container.querySelector(`.${cls(name)}`);
+          if (result) {
+            expect(panel).not.toBeNull();
+          } else {
+            expect(panel).toBeNull();
+          }
+        }
+      });
+    });
+  });
+});

--- a/apps/calendar/src/components/view/day.spec.tsx
+++ b/apps/calendar/src/components/view/day.spec.tsx
@@ -1,37 +1,22 @@
 import { h } from 'preact';
 
-import { render } from '@testing-library/preact';
-
 import { Day } from '@src/components/view/day';
 import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
-import { initCalendarStore, StoreProvider } from '@src/contexts/calendarStore';
-import { EventBusProvider } from '@src/contexts/eventBus';
-import { initThemeStore, ThemeProvider } from '@src/contexts/themeStore';
+import { initCalendarStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
-import { EventBusImpl } from '@src/utils/eventBus';
-import { isBoolean } from '@src/utils/type';
+import { getActivePanels } from '@src/helpers/view';
+import { render } from '@src/test/utils';
 
 import type { WeekOptions } from '@t/options';
 
 describe('day', () => {
   function setup(weekOptions: WeekOptions) {
-    const eventBus = new EventBusImpl();
     const store = initCalendarStore();
-    const theme = initThemeStore();
-
     store.getState().dispatch.options.setOptions({
       week: weekOptions,
     });
 
-    return render(
-      <EventBusProvider value={eventBus}>
-        <ThemeProvider store={theme}>
-          <StoreProvider store={store}>
-            <Day />
-          </StoreProvider>
-        </ThemeProvider>
-      </EventBusProvider>
-    );
+    return render(<Day />, { store });
   }
 
   describe('eventView and taskView options', () => {
@@ -42,27 +27,11 @@ describe('day', () => {
       { eventView: ['allday', 'time'], taskView: false },
     ];
 
-    function getExpectedResult({ eventView, taskView }: WeekOptions) {
-      const result: {
-        milestone?: boolean;
-        task?: boolean;
-        allday?: boolean;
-        time?: boolean;
-      } = {};
+    const panels = [...DEFAULT_TASK_PANEL, ...DEFAULT_EVENT_PANEL];
 
-      DEFAULT_EVENT_PANEL.forEach((eventPanel) => {
-        result[eventPanel] = isBoolean(eventView) ? eventView : !!eventView?.includes(eventPanel);
-      });
-
-      DEFAULT_TASK_PANEL.forEach((taskPanel) => {
-        result[taskPanel] = isBoolean(taskView) ? taskView : !!taskView?.includes(taskPanel);
-      });
-
-      return result;
-    }
-
-    cases.forEach((weekOptions) => {
-      it(`show/hide the panels in the daily view: { eventView: ${weekOptions.eventView}, taskView: ${weekOptions.taskView} }`, () => {
+    it.each(cases)(
+      'should show/hide the panels in the daily view: { eventView: $eventView, taskView: $eventView }',
+      (weekOptions) => {
         // Given
         const { container } = setup(weekOptions);
 
@@ -70,16 +39,19 @@ describe('day', () => {
         // Nothing
 
         // Then
-        const results = getExpectedResult(weekOptions);
-        for (const [name, result] of Object.entries(results)) {
-          const panel = container.querySelector(`.${cls(name)}`);
-          if (result) {
-            expect(panel).not.toBeNull();
+        const activePanels = getActivePanels(
+          weekOptions.taskView ?? false,
+          weekOptions.eventView ?? false
+        );
+        panels.forEach((panel) => {
+          const panelEl = container.querySelector(`.${cls(panel)}`);
+          if (activePanels.includes(panel)) {
+            expect(panelEl).not.toBeNull();
           } else {
-            expect(panel).toBeNull();
+            expect(panelEl).toBeNull();
           }
-        }
-      });
-    });
+        });
+      }
+    );
   });
 });

--- a/apps/calendar/src/components/view/day.tsx
+++ b/apps/calendar/src/components/view/day.tsx
@@ -31,7 +31,7 @@ import type { AlldayEventCategory } from '@t/panel';
 function useDayViewState() {
   const calendar = useStore(calendarSelector);
   const options = useStore(optionsSelector);
-  const { dayGridRows: gridRowLayout } = useStore(weekViewLayoutSelector);
+  const { dayGridRows: gridRowLayout, lastPanelType } = useStore(weekViewLayoutSelector);
   const { renderDate } = useStore(viewSelector);
 
   return useMemo(
@@ -39,14 +39,15 @@ function useDayViewState() {
       calendar,
       options,
       gridRowLayout,
+      lastPanelType,
       renderDate,
     }),
-    [calendar, options, gridRowLayout, renderDate]
+    [calendar, options, gridRowLayout, lastPanelType, renderDate]
   );
 }
 
 export function Day() {
-  const { calendar, options, gridRowLayout, renderDate } = useDayViewState();
+  const { calendar, options, gridRowLayout, lastPanelType, renderDate } = useDayViewState();
   const [timePanel, setTimePanelRef] = useDOMNode<HTMLDivElement>();
 
   const weekOptions = options.week as Required<WeekOptions>;
@@ -87,14 +88,14 @@ export function Day() {
       const rowType = key as AlldayEventCategory;
 
       return (
-        <Panel key={rowType} name={rowType} resizable>
+        <Panel key={rowType} name={rowType} resizable={rowType !== lastPanelType}>
           {rowType === 'allday' ? (
             <AlldayGridRow
               events={dayGridEvents[rowType]}
               rowStyleInfo={rowStyleInfo}
               gridColWidthMap={cellWidthMap}
               weekDates={days}
-              height={gridRowLayout[rowType].height}
+              height={gridRowLayout[rowType]?.height}
               options={weekOptions}
             />
           ) : (
@@ -102,7 +103,7 @@ export function Day() {
               category={rowType}
               events={dayGridEvents[rowType]}
               weekDates={days}
-              height={gridRowLayout[rowType].height}
+              height={gridRowLayout[rowType]?.height}
               options={weekOptions}
               gridColWidthMap={cellWidthMap}
             />
@@ -125,9 +126,11 @@ export function Day() {
         />
       </Panel>
       {gridRows}
-      <Panel name="time" autoSize={1} ref={setTimePanelRef}>
-        <TimeGrid events={dayGridEvents.time} timeGridData={timeGridData} />
-      </Panel>
+      {displayPanel.includes('time') ? (
+        <Panel name="time" autoSize={1} ref={setTimePanelRef}>
+          <TimeGrid events={dayGridEvents.time} timeGridData={timeGridData} />
+        </Panel>
+      ) : null}
     </Layout>
   );
 }

--- a/apps/calendar/src/components/view/day.tsx
+++ b/apps/calendar/src/components/view/day.tsx
@@ -49,9 +49,9 @@ export function Day() {
   const { calendar, options, gridRowLayout, renderDate } = useDayViewState();
   const [timePanel, setTimePanelRef] = useDOMNode<HTMLDivElement>();
 
-  const { eventView, taskView } = options;
   const weekOptions = options.week as Required<WeekOptions>;
-  const { narrowWeekend, startDayOfWeek, workweek, hourStart, hourEnd } = weekOptions;
+  const { narrowWeekend, startDayOfWeek, workweek, hourStart, hourEnd, eventView, taskView } =
+    weekOptions;
   const days = useMemo(() => [renderDate], [renderDate]);
   const dayNames = getDayNames(days);
   const { rowStyleInfo, cellWidthMap } = getRowStyleInfo(
@@ -103,7 +103,7 @@ export function Day() {
               events={dayGridEvents[rowType]}
               weekDates={days}
               height={gridRowLayout[rowType].height}
-              options={options.week}
+              options={weekOptions}
               gridColWidthMap={cellWidthMap}
             />
           )}

--- a/apps/calendar/src/components/view/day.tsx
+++ b/apps/calendar/src/components/view/day.tsx
@@ -7,14 +7,13 @@ import { OtherGridRow } from '@src/components/dayGridWeek/otherGridRow';
 import { Layout } from '@src/components/layout';
 import { Panel } from '@src/components/panel';
 import { TimeGrid } from '@src/components/timeGrid/timeGrid';
-import { DEFAULT_WEEK_PANEL_TYPES } from '@src/constants/layout';
 import { WEEK_DAYNAME_BORDER, WEEK_DAYNAME_HEIGHT } from '@src/constants/style';
 import { useStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
 import { getDayNames } from '@src/helpers/dayName';
 import { getVisibleEventCollection } from '@src/helpers/events';
 import { createTimeGridData, getDayGridEvents } from '@src/helpers/grid';
-import { getDisplayPanel } from '@src/helpers/view';
+import { getActivePanels } from '@src/helpers/view';
 import { useDOMNode } from '@src/hooks/common/useDOMNode';
 import { useTimeGridScrollSync } from '@src/hooks/timeGrid/useTimeGridScrollSync';
 import {
@@ -81,36 +80,38 @@ export function Day() {
       }),
     [days, weekOptions.hourEnd, weekOptions.hourStart]
   );
-  const displayPanel = getDisplayPanel(taskView, eventView);
-  const gridRows = displayPanel
-    .filter((panel) => DEFAULT_WEEK_PANEL_TYPES.includes(panel))
-    .map((key) => {
-      const rowType = key as AlldayEventCategory;
+  const activePanels = getActivePanels(taskView, eventView);
+  const gridRows = activePanels.map((key) => {
+    if (key === 'time') {
+      return null;
+    }
 
-      return (
-        <Panel key={rowType} name={rowType} resizable={rowType !== lastPanelType}>
-          {rowType === 'allday' ? (
-            <AlldayGridRow
-              events={dayGridEvents[rowType]}
-              rowStyleInfo={rowStyleInfo}
-              gridColWidthMap={cellWidthMap}
-              weekDates={days}
-              height={gridRowLayout[rowType]?.height}
-              options={weekOptions}
-            />
-          ) : (
-            <OtherGridRow
-              category={rowType}
-              events={dayGridEvents[rowType]}
-              weekDates={days}
-              height={gridRowLayout[rowType]?.height}
-              options={weekOptions}
-              gridColWidthMap={cellWidthMap}
-            />
-          )}
-        </Panel>
-      );
-    });
+    const rowType = key as AlldayEventCategory;
+
+    return (
+      <Panel key={rowType} name={rowType} resizable={rowType !== lastPanelType}>
+        {rowType === 'allday' ? (
+          <AlldayGridRow
+            events={dayGridEvents[rowType]}
+            rowStyleInfo={rowStyleInfo}
+            gridColWidthMap={cellWidthMap}
+            weekDates={days}
+            height={gridRowLayout[rowType]?.height}
+            options={weekOptions}
+          />
+        ) : (
+          <OtherGridRow
+            category={rowType}
+            events={dayGridEvents[rowType]}
+            weekDates={days}
+            height={gridRowLayout[rowType]?.height}
+            options={weekOptions}
+            gridColWidthMap={cellWidthMap}
+          />
+        )}
+      </Panel>
+    );
+  });
 
   useTimeGridScrollSync(timePanel, timeGridData.rows.length);
 
@@ -126,7 +127,7 @@ export function Day() {
         />
       </Panel>
       {gridRows}
-      {displayPanel.includes('time') ? (
+      {activePanels.includes('time') ? (
         <Panel name="time" autoSize={1} ref={setTimePanelRef}>
           <TimeGrid events={dayGridEvents.time} timeGridData={timeGridData} />
         </Panel>

--- a/apps/calendar/src/components/view/week.spec.tsx
+++ b/apps/calendar/src/components/view/week.spec.tsx
@@ -11,10 +11,7 @@ import type { WeekOptions } from '@t/options';
 
 describe('week', () => {
   function setup(weekOptions: WeekOptions) {
-    const store = initCalendarStore();
-    store.getState().dispatch.options.setOptions({
-      week: weekOptions,
-    });
+    const store = initCalendarStore({ week: weekOptions });
 
     return render(<Week />, { store });
   }

--- a/apps/calendar/src/components/view/week.spec.tsx
+++ b/apps/calendar/src/components/view/week.spec.tsx
@@ -1,0 +1,85 @@
+import { h } from 'preact';
+
+import { render } from '@testing-library/preact';
+
+import { Week } from '@src/components/view/week';
+import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
+import { initCalendarStore, StoreProvider } from '@src/contexts/calendarStore';
+import { EventBusProvider } from '@src/contexts/eventBus';
+import { initThemeStore, ThemeProvider } from '@src/contexts/themeStore';
+import { cls } from '@src/helpers/css';
+import { EventBusImpl } from '@src/utils/eventBus';
+import { isBoolean } from '@src/utils/type';
+
+import type { WeekOptions } from '@t/options';
+
+describe('week', () => {
+  function setup(weekOptions: WeekOptions) {
+    const eventBus = new EventBusImpl();
+    const store = initCalendarStore();
+    const theme = initThemeStore();
+
+    store.getState().dispatch.options.setOptions({
+      week: weekOptions,
+    });
+
+    return render(
+      <EventBusProvider value={eventBus}>
+        <ThemeProvider store={theme}>
+          <StoreProvider store={store}>
+            <Week />
+          </StoreProvider>
+        </ThemeProvider>
+      </EventBusProvider>
+    );
+  }
+
+  describe('eventView and taskView options', () => {
+    const cases: WeekOptions[] = [
+      { eventView: true, taskView: true },
+      { eventView: false, taskView: false },
+      { eventView: ['allday'], taskView: ['milestone'] },
+      { eventView: ['allday', 'time'], taskView: false },
+    ];
+
+    function getExpectedResult({ eventView, taskView }: WeekOptions) {
+      const result: {
+        milestone?: boolean;
+        task?: boolean;
+        allday?: boolean;
+        time?: boolean;
+      } = {};
+
+      DEFAULT_EVENT_PANEL.forEach((eventPanel) => {
+        result[eventPanel] = isBoolean(eventView) ? eventView : !!eventView?.includes(eventPanel);
+      });
+
+      DEFAULT_TASK_PANEL.forEach((taskPanel) => {
+        result[taskPanel] = isBoolean(taskView) ? taskView : !!taskView?.includes(taskPanel);
+      });
+
+      return result;
+    }
+
+    cases.forEach((weekOptions) => {
+      it(`show/hide the panels in the weekly view: { eventView: ${weekOptions.eventView}, taskView: ${weekOptions.taskView} }`, () => {
+        // Given
+        const { container } = setup(weekOptions);
+
+        // When
+        // Nothing
+
+        // Then
+        const results = getExpectedResult(weekOptions);
+        for (const [name, result] of Object.entries(results)) {
+          const panel = container.querySelector(`.${cls(name)}`);
+          if (result) {
+            expect(panel).not.toBeNull();
+          } else {
+            expect(panel).toBeNull();
+          }
+        }
+      });
+    });
+  });
+});

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -31,7 +31,7 @@ import type { AlldayEventCategory } from '@t/panel';
 function useWeekViewState() {
   const options = useStore(optionsSelector);
   const calendar = useStore(calendarSelector);
-  const { dayGridRows: gridRowLayout } = useStore(weekViewLayoutSelector);
+  const { dayGridRows: gridRowLayout, lastPanelType } = useStore(weekViewLayoutSelector);
   const { renderDate } = useStore(viewSelector);
 
   return useMemo(
@@ -39,14 +39,15 @@ function useWeekViewState() {
       options,
       calendar,
       gridRowLayout,
+      lastPanelType,
       renderDate,
     }),
-    [calendar, gridRowLayout, options, renderDate]
+    [calendar, gridRowLayout, lastPanelType, options, renderDate]
   );
 }
 
 export function Week() {
-  const { options, calendar, gridRowLayout, renderDate } = useWeekViewState();
+  const { options, calendar, gridRowLayout, lastPanelType, renderDate } = useWeekViewState();
   const [timePanel, setTimePanelRef] = useDOMNode<HTMLDivElement>();
 
   const weekOptions = options.week as Required<WeekOptions>;
@@ -92,14 +93,14 @@ export function Week() {
       const rowType = key as AlldayEventCategory;
 
       return (
-        <Panel name={rowType} key={rowType} resizable>
+        <Panel name={rowType} key={rowType} resizable={rowType !== lastPanelType}>
           {rowType === 'allday' ? (
             <AlldayGridRow
               events={eventByPanel[rowType]}
               rowStyleInfo={rowStyleInfo}
               gridColWidthMap={cellWidthMap}
               weekDates={weekDates}
-              height={gridRowLayout[rowType].height}
+              height={gridRowLayout[rowType]?.height}
               options={weekOptions}
             />
           ) : (
@@ -107,7 +108,7 @@ export function Week() {
               category={rowType}
               events={eventByPanel[rowType]}
               weekDates={weekDates}
-              height={gridRowLayout[rowType].height}
+              height={gridRowLayout[rowType]?.height}
               options={weekOptions}
               gridColWidthMap={cellWidthMap}
             />
@@ -131,9 +132,11 @@ export function Week() {
         />
       </Panel>
       {dayGridRows}
-      <Panel name="time" autoSize={1} ref={setTimePanelRef}>
-        <TimeGrid events={eventByPanel.time} timeGridData={timeGridData} />
-      </Panel>
+      {displayPanel.includes('time') ? (
+        <Panel name="time" autoSize={1} ref={setTimePanelRef}>
+          <TimeGrid events={eventByPanel.time} timeGridData={timeGridData} />
+        </Panel>
+      ) : null}
     </Layout>
   );
 }

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -7,14 +7,13 @@ import { OtherGridRow } from '@src/components/dayGridWeek/otherGridRow';
 import { Layout } from '@src/components/layout';
 import { Panel } from '@src/components/panel';
 import { TimeGrid } from '@src/components/timeGrid/timeGrid';
-import { DEFAULT_WEEK_PANEL_TYPES } from '@src/constants/layout';
 import { WEEK_DAYNAME_BORDER, WEEK_DAYNAME_HEIGHT } from '@src/constants/style';
 import { useStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
 import { getDayNames } from '@src/helpers/dayName';
 import { getVisibleEventCollection } from '@src/helpers/events';
 import { createTimeGridData, getDayGridEvents, getWeekDates } from '@src/helpers/grid';
-import { getDisplayPanel } from '@src/helpers/view';
+import { getActivePanels } from '@src/helpers/view';
 import { useDOMNode } from '@src/hooks/common/useDOMNode';
 import { useTimeGridScrollSync } from '@src/hooks/timeGrid/useTimeGridScrollSync';
 import {
@@ -86,36 +85,38 @@ export function Week() {
     [weekDates, weekOptions.hourEnd, weekOptions.hourStart]
   );
 
-  const displayPanel = getDisplayPanel(taskView, eventView);
-  const dayGridRows = displayPanel
-    .filter((panel) => DEFAULT_WEEK_PANEL_TYPES.includes(panel))
-    .map((key) => {
-      const rowType = key as AlldayEventCategory;
+  const activePanels = getActivePanels(taskView, eventView);
+  const dayGridRows = activePanels.map((key) => {
+    if (key === 'time') {
+      return null;
+    }
 
-      return (
-        <Panel name={rowType} key={rowType} resizable={rowType !== lastPanelType}>
-          {rowType === 'allday' ? (
-            <AlldayGridRow
-              events={eventByPanel[rowType]}
-              rowStyleInfo={rowStyleInfo}
-              gridColWidthMap={cellWidthMap}
-              weekDates={weekDates}
-              height={gridRowLayout[rowType]?.height}
-              options={weekOptions}
-            />
-          ) : (
-            <OtherGridRow
-              category={rowType}
-              events={eventByPanel[rowType]}
-              weekDates={weekDates}
-              height={gridRowLayout[rowType]?.height}
-              options={weekOptions}
-              gridColWidthMap={cellWidthMap}
-            />
-          )}
-        </Panel>
-      );
-    });
+    const rowType = key as AlldayEventCategory;
+
+    return (
+      <Panel name={rowType} key={rowType} resizable={rowType !== lastPanelType}>
+        {rowType === 'allday' ? (
+          <AlldayGridRow
+            events={eventByPanel[rowType]}
+            rowStyleInfo={rowStyleInfo}
+            gridColWidthMap={cellWidthMap}
+            weekDates={weekDates}
+            height={gridRowLayout[rowType]?.height}
+            options={weekOptions}
+          />
+        ) : (
+          <OtherGridRow
+            category={rowType}
+            events={eventByPanel[rowType]}
+            weekDates={weekDates}
+            height={gridRowLayout[rowType]?.height}
+            options={weekOptions}
+            gridColWidthMap={cellWidthMap}
+          />
+        )}
+      </Panel>
+    );
+  });
 
   useTimeGridScrollSync(timePanel, timeGridData.rows.length);
 
@@ -132,7 +133,7 @@ export function Week() {
         />
       </Panel>
       {dayGridRows}
-      {displayPanel.includes('time') ? (
+      {activePanels.includes('time') ? (
         <Panel name="time" autoSize={1} ref={setTimePanelRef}>
           <TimeGrid events={eventByPanel.time} timeGridData={timeGridData} />
         </Panel>

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -117,6 +117,7 @@ export function Week() {
       </Panel>
     );
   });
+  const hasTimePanel = useMemo(() => activePanels.includes('time'), [activePanels]);
 
   useTimeGridScrollSync(timePanel, timeGridData.rows.length);
 
@@ -133,7 +134,7 @@ export function Week() {
         />
       </Panel>
       {dayGridRows}
-      {activePanels.includes('time') ? (
+      {hasTimePanel ? (
         <Panel name="time" autoSize={1} ref={setTimePanelRef}>
           <TimeGrid events={eventByPanel.time} timeGridData={timeGridData} />
         </Panel>

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -49,9 +49,9 @@ export function Week() {
   const { options, calendar, gridRowLayout, renderDate } = useWeekViewState();
   const [timePanel, setTimePanelRef] = useDOMNode<HTMLDivElement>();
 
-  const { eventView, taskView } = options;
   const weekOptions = options.week as Required<WeekOptions>;
-  const { narrowWeekend, startDayOfWeek, workweek, hourStart, hourEnd } = weekOptions;
+  const { narrowWeekend, startDayOfWeek, workweek, hourStart, hourEnd, eventView, taskView } =
+    weekOptions;
   const weekDates = useMemo(() => getWeekDates(renderDate, weekOptions), [renderDate, weekOptions]);
   const dayNames = getDayNames(weekDates);
   const { rowStyleInfo, cellWidthMap } = getRowStyleInfo(

--- a/apps/calendar/src/constants/layout.ts
+++ b/apps/calendar/src/constants/layout.ts
@@ -1,3 +1,1 @@
 export const DEFAULT_RESIZER_LENGTH = 3;
-
-export const DEFAULT_WEEK_PANEL_TYPES = ['milestone', 'task', 'allday'];

--- a/apps/calendar/src/constants/view.ts
+++ b/apps/calendar/src/constants/view.ts
@@ -1,4 +1,4 @@
-import type { eventViewValue, taskViewValue, ViewType } from '@t/options';
+import type { EventView, TaskView, ViewType } from '@t/options';
 
 export const VIEW_TYPE: {
   [key: string]: ViewType;
@@ -8,6 +8,6 @@ export const VIEW_TYPE: {
   DAY: 'day',
 };
 
-export const DEFAULT_TASK_PANEL: taskViewValue[] = ['milestone', 'task'];
+export const DEFAULT_TASK_PANEL: TaskView[] = ['milestone', 'task'];
 
-export const DEFAULT_EVENT_PANEL: eventViewValue[] = ['allday', 'time'];
+export const DEFAULT_EVENT_PANEL: EventView[] = ['allday', 'time'];

--- a/apps/calendar/src/constants/view.ts
+++ b/apps/calendar/src/constants/view.ts
@@ -1,4 +1,4 @@
-import type { ViewType } from '@t/options';
+import type { eventViewValue, taskViewValue, ViewType } from '@t/options';
 
 export const VIEW_TYPE: {
   [key: string]: ViewType;
@@ -8,6 +8,6 @@ export const VIEW_TYPE: {
   DAY: 'day',
 };
 
-export const DEFAULT_TASK_PANEL = ['milestone', 'task'];
+export const DEFAULT_TASK_PANEL: taskViewValue[] = ['milestone', 'task'];
 
-export const DEFAULT_EVENT_PANEL = ['allday', 'time'];
+export const DEFAULT_EVENT_PANEL: eventViewValue[] = ['allday', 'time'];

--- a/apps/calendar/src/factory/calendarControl.tsx
+++ b/apps/calendar/src/factory/calendarControl.tsx
@@ -98,8 +98,6 @@ export default abstract class CalendarControl implements EventBus<ExternalEventT
   private initOptions(options: Options = {}): Options {
     const {
       defaultView = 'week',
-      taskView = true,
-      eventView = true,
       template = {},
       week = {},
       month = {},
@@ -112,8 +110,6 @@ export default abstract class CalendarControl implements EventBus<ExternalEventT
 
     return {
       defaultView,
-      taskView,
-      eventView,
       template,
       week,
       month,

--- a/apps/calendar/src/helpers/view.ts
+++ b/apps/calendar/src/helpers/view.ts
@@ -2,23 +2,23 @@ import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
 
 import type { WeekOptions } from '@t/options';
 
-export function getDisplayPanel(
+export function getActivePanels(
   taskView: Required<WeekOptions>['taskView'],
   eventView: Required<WeekOptions>['eventView']
 ) {
-  const displayPanel: string[] = [];
+  const activePanels: string[] = [];
 
   if (taskView === true) {
-    displayPanel.push(...DEFAULT_TASK_PANEL);
+    activePanels.push(...DEFAULT_TASK_PANEL);
   } else if (Array.isArray(taskView)) {
-    displayPanel.push(...taskView);
+    activePanels.push(...taskView);
   }
 
   if (eventView === true) {
-    displayPanel.push(...DEFAULT_EVENT_PANEL);
+    activePanels.push(...DEFAULT_EVENT_PANEL);
   } else if (Array.isArray(eventView)) {
-    displayPanel.push(...eventView);
+    activePanels.push(...eventView);
   }
 
-  return displayPanel;
+  return activePanels;
 }

--- a/apps/calendar/src/helpers/view.ts
+++ b/apps/calendar/src/helpers/view.ts
@@ -1,10 +1,10 @@
 import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
 
-import type { Options } from '@t/options';
+import type { WeekOptions } from '@t/options';
 
 export function getDisplayPanel(
-  taskView: Required<Options>['taskView'],
-  eventView: Required<Options>['eventView']
+  taskView: Required<WeekOptions>['taskView'],
+  eventView: Required<WeekOptions>['eventView']
 ) {
   const displayPanel: string[] = [];
 

--- a/apps/calendar/src/slices/layout.ts
+++ b/apps/calendar/src/slices/layout.ts
@@ -1,6 +1,6 @@
 import produce from 'immer';
 
-import { DEFAULT_RESIZER_LENGTH, DEFAULT_WEEK_PANEL_TYPES } from '@src/constants/layout';
+import { DEFAULT_RESIZER_LENGTH } from '@src/constants/layout';
 import { DEFAULT_PANEL_HEIGHT } from '@src/constants/style';
 
 import type { CalendarStore, SetState } from '@t/store';
@@ -9,9 +9,9 @@ export type WeekGridRows = 'milestone' | 'task' | 'allday' | string;
 
 // @TODO: Change name to layout & merge slice into layout
 export type WeekViewLayoutSlice = {
-  lastPanelType: string | null;
   layout: number;
   weekViewLayout: {
+    lastPanelType: string | null;
     dayGridRows: {
       [row in WeekGridRows]: {
         height: number;
@@ -46,16 +46,10 @@ function getRestPanelHeight(
 
 export function createWeekViewLayoutSlice(): WeekViewLayoutSlice {
   return {
-    lastPanelType: null,
     layout: 500,
     weekViewLayout: {
-      dayGridRows: DEFAULT_WEEK_PANEL_TYPES.reduce((acc, rowName) => {
-        acc[rowName] = {
-          height: DEFAULT_PANEL_HEIGHT,
-        };
-
-        return acc;
-      }, {} as WeekViewLayoutSlice['weekViewLayout']['dayGridRows']),
+      lastPanelType: null,
+      dayGridRows: {} as WeekViewLayoutSlice['weekViewLayout']['dayGridRows'],
     },
   };
 }
@@ -67,12 +61,12 @@ export function createWeekViewLayoutDispatchers(
     setLastPanelType: (type) => {
       set(
         produce((state) => {
-          state.lastPanelType = type;
+          state.weekViewLayout.lastPanelType = type;
 
           if (type) {
             state.weekViewLayout.dayGridRows[type].height = getRestPanelHeight(
               state.weekViewLayout.dayGridRows,
-              state.lastPanelType,
+              type,
               state.layout
             );
           }
@@ -82,13 +76,13 @@ export function createWeekViewLayoutDispatchers(
     updateLayoutHeight: (height) =>
       set(
         produce((state) => {
-          const { lastPanelType } = state;
+          const { lastPanelType } = state.weekViewLayout;
 
           state.layout = height;
           if (lastPanelType) {
             state.weekViewLayout.dayGridRows[lastPanelType].height = getRestPanelHeight(
               state.weekViewLayout.dayGridRows,
-              state.lastPanelType,
+              lastPanelType,
               height
             );
           }
@@ -97,13 +91,13 @@ export function createWeekViewLayoutDispatchers(
     updateDayGridRowHeight: ({ rowName, height }) =>
       set(
         produce((state) => {
-          const { lastPanelType } = state;
+          const { lastPanelType } = state.weekViewLayout;
 
           state.weekViewLayout.dayGridRows[rowName] = { height };
           if (lastPanelType) {
             state.weekViewLayout.dayGridRows[lastPanelType].height = getRestPanelHeight(
               state.weekViewLayout.dayGridRows,
-              state.lastPanelType,
+              lastPanelType,
               state.layout
             );
           }
@@ -112,7 +106,7 @@ export function createWeekViewLayoutDispatchers(
     updateDayGridRowHeightByDiff: ({ rowName, diff }) =>
       set(
         produce((state) => {
-          const { lastPanelType } = state;
+          const { lastPanelType } = state.weekViewLayout;
           const height =
             state.weekViewLayout.dayGridRows?.[rowName]?.height ?? DEFAULT_PANEL_HEIGHT;
 
@@ -120,7 +114,7 @@ export function createWeekViewLayoutDispatchers(
           if (lastPanelType) {
             state.weekViewLayout.dayGridRows[lastPanelType].height = getRestPanelHeight(
               state.weekViewLayout.dayGridRows,
-              state.lastPanelType,
+              lastPanelType,
               state.layout
             );
           }

--- a/apps/calendar/src/slices/options.ts
+++ b/apps/calendar/src/slices/options.ts
@@ -1,10 +1,10 @@
 import produce from 'immer';
 import range from 'tui-code-snippet/array/range';
-import isBoolean from 'tui-code-snippet/type/isBoolean';
 
 import { getDayName } from '@src/helpers/dayName';
 import { Day } from '@src/time/datetime';
 import { mergeObject } from '@src/utils/object';
+import { isBoolean } from '@src/utils/type';
 
 import type { EventModelData } from '@t/events';
 import type { GridSelectionOptions, Options } from '@t/options';
@@ -37,6 +37,8 @@ function initializeWeekOptions(weekOptions: Options['week'] = {}): CalendarWeekO
     ],
     hourStart: 0,
     hourEnd: 24,
+    eventView: true,
+    taskView: true,
     ...weekOptions,
   };
 }
@@ -102,8 +104,6 @@ export function createOptionsSlice(options: Options = {}): OptionsSlice {
   return {
     options: {
       defaultView: options.defaultView ?? 'week',
-      taskView: options.taskView ?? true,
-      eventView: options.eventView ?? true,
       useCreationPopup: options.useCreationPopup ?? false,
       useDetailPopup: options.useDetailPopup ?? false,
       isReadOnly: options.isReadOnly ?? false,

--- a/apps/calendar/types/options.d.ts
+++ b/apps/calendar/types/options.d.ts
@@ -7,6 +7,9 @@ import type { EventModelData } from '@t/events';
 import type { TemplateConfig } from '@t/template';
 import type { ThemeState } from '@t/theme';
 
+type eventViewValue = 'allday' | 'time';
+type taskViewValue = 'milestone' | 'task';
+
 export interface WeekOptions {
   startDayOfWeek?: number;
   daynames?: string[];
@@ -17,6 +20,8 @@ export interface WeekOptions {
   timezones?: TimezoneConfig[];
   hourStart?: number;
   hourEnd?: number;
+  eventView?: boolean | eventViewValue[];
+  taskView?: boolean | taskViewValue[];
 }
 
 export interface MonthOptions {
@@ -77,8 +82,6 @@ export type ViewType = 'month' | 'week' | 'day';
 // @TODO: Options 정의 필요
 export interface Options {
   defaultView?: ViewType;
-  taskView?: boolean | string[];
-  eventView?: boolean | string[];
   theme?: DeepPartial<ThemeState>;
   template?: TemplateConfig;
   week?: WeekOptions;

--- a/apps/calendar/types/options.d.ts
+++ b/apps/calendar/types/options.d.ts
@@ -7,8 +7,8 @@ import type { EventModelData } from '@t/events';
 import type { TemplateConfig } from '@t/template';
 import type { ThemeState } from '@t/theme';
 
-type eventViewValue = 'allday' | 'time';
-type taskViewValue = 'milestone' | 'task';
+type EventView = 'allday' | 'time';
+type TaskView = 'milestone' | 'task';
 
 export interface WeekOptions {
   startDayOfWeek?: number;
@@ -20,8 +20,8 @@ export interface WeekOptions {
   timezones?: TimezoneConfig[];
   hourStart?: number;
   hourEnd?: number;
-  eventView?: boolean | eventViewValue[];
-  taskView?: boolean | taskViewValue[];
+  eventView?: boolean | EventView[];
+  taskView?: boolean | TaskView[];
 }
 
 export interface MonthOptions {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ const config: PlaywrightTestConfig = {
       height: 900,
     },
     launchOptions: {
-      slowMo: isCI ? 150 : undefined,
+      slowMo: isCI ? 300 : 150,
     }
   },
   webServer: {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

* [BREAKING CHANGE] `scheduleView` and `taskView` options are deprecated.
  * Instead, use `week.eventView` and `week.taskView`.
  ```js
  const options = {
    // scheduleView: true, // deprecated
    // taskView: true, // deprecated
    week: {
      eventView: true, // set by a boolean value
      taskView: ['milestone', 'task'] // or array
    }
  };
  ```
  * The default values of `week.eventView` and `week.taskView` are `true`.
* Implement `week.eventView` and `week.taskView`.

### Result

* When the options are `{ week: { eventView: ['allday'], taskView: ['task'] } }`
  * ![image](https://user-images.githubusercontent.com/8615506/165203313-5394f3fb-f728-46e6-a0a8-7c5344ddfcf5.png)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
