### PR TITLE
feat: implement eventFilter option

### DIFF
--- a/apps/calendar/index.d.ts
+++ b/apps/calendar/index.d.ts
@@ -169,7 +169,6 @@ export interface IMonthOptions {
       height?: number;
     };
   };
-  eventFilter?: (eventData: EventModelData) => boolean;
 }
 
 export interface IGridSelectionOptions {
@@ -247,6 +246,7 @@ export interface IOptions {
   isReadOnly?: boolean;
   usageStatistics?: boolean;
   timezone?: ICustomTimezone;
+  eventFilter?: (event: EventModelData) => boolean;
 }
 
 export default class Calendar {

--- a/apps/calendar/src/components/view/day.tsx
+++ b/apps/calendar/src/components/view/day.tsx
@@ -11,9 +11,9 @@ import { WEEK_DAYNAME_BORDER, WEEK_DAYNAME_HEIGHT } from '@src/constants/style';
 import { useStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
 import { getDayNames } from '@src/helpers/dayName';
-import { getVisibleEventCollection } from '@src/helpers/events';
 import { createTimeGridData, getDayGridEvents } from '@src/helpers/grid';
 import { getActivePanels } from '@src/helpers/view';
+import { useCalendarData } from '@src/hooks/calendar/useCalendarData';
 import { useDOMNode } from '@src/hooks/common/useDOMNode';
 import { useTimeGridScrollSync } from '@src/hooks/timeGrid/useTimeGridScrollSync';
 import {
@@ -60,13 +60,7 @@ export function Day() {
     startDayOfWeek,
     workweek
   );
-  const calendarData = useMemo(
-    () => ({
-      ...calendar,
-      events: getVisibleEventCollection(calendar.events),
-    }),
-    [calendar]
-  );
+  const calendarData = useCalendarData(calendar, options.eventFilter);
   const dayGridEvents = getDayGridEvents(days, calendarData, {
     narrowWeekend,
     hourStart,

--- a/apps/calendar/src/components/view/month.spec.tsx
+++ b/apps/calendar/src/components/view/month.spec.tsx
@@ -2,65 +2,41 @@ import { h } from 'preact';
 
 import { screen } from '@testing-library/preact';
 
-import { Day } from '@src/components/view/day';
-import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
+import { Month } from '@src/components/view/month';
 import { initCalendarStore } from '@src/contexts/calendarStore';
-import { cls } from '@src/helpers/css';
-import { getActivePanels } from '@src/helpers/view';
 import EventModel from '@src/model/eventModel';
 import { render } from '@src/test/utils';
 import TZDate from '@src/time/date';
+import { noop } from '@src/utils/noop';
 
 import type { EventModelData } from '@t/events';
-import type { Options, WeekOptions } from '@t/options';
+import type { Options } from '@t/options';
 
-describe('day', () => {
+describe('Month', () => {
   function setup(options: Options, events?: EventModel[]) {
     const store = initCalendarStore(options);
     if (events) {
       store.getState().dispatch.calendar.createEvents(events);
     }
 
-    return render(<Day />, { store });
+    return render(<Month />, { store });
   }
 
-  describe('eventView and taskView options', () => {
-    const cases: WeekOptions[] = [
-      { eventView: true, taskView: true },
-      { eventView: false, taskView: false },
-      { eventView: ['allday'], taskView: ['milestone'] },
-      { eventView: ['allday', 'time'], taskView: false },
-    ];
-
-    const panels = [...DEFAULT_TASK_PANEL, ...DEFAULT_EVENT_PANEL];
-
-    it.each(cases)(
-      'should show/hide the panels in the daily view: { eventView: $eventView, taskView: $eventView }',
-      (weekOptions) => {
-        // Given
-        const { container } = setup({ week: weekOptions });
-
-        // When
-        // Nothing
-
-        // Then
-        const activePanels = getActivePanels(
-          weekOptions.taskView ?? false,
-          weekOptions.eventView ?? false
-        );
-        panels.forEach((panel) => {
-          const panelEl = container.querySelector(`.${cls(panel)}`);
-          if (activePanels.includes(panel)) {
-            expect(panelEl).not.toBeNull();
-          } else {
-            expect(panelEl).toBeNull();
-          }
-        });
-      }
-    );
-  });
-
   describe('eventFilter option', () => {
+    beforeEach(() => {
+      jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+        x: 0,
+        y: 0,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: 100,
+        height: 100,
+        toJSON: noop,
+      });
+    });
+
     const events: EventModel[] = [];
     for (let i = 0; i < 2; i += 1) {
       events.push(

--- a/apps/calendar/src/components/view/month.spec.tsx
+++ b/apps/calendar/src/components/view/month.spec.tsx
@@ -12,71 +12,73 @@ import { noop } from '@src/utils/noop';
 import type { EventModelData } from '@t/events';
 import type { Options } from '@t/options';
 
-describe('Month', () => {
-  function setup(options: Options, events?: EventModel[]) {
-    const store = initCalendarStore(options);
-    if (events) {
-      store.getState().dispatch.calendar.createEvents(events);
-    }
-
-    return render(<Month />, { store });
+function setup(options: Options, events?: EventModel[]) {
+  const store = initCalendarStore(options);
+  if (events) {
+    store.getState().dispatch.calendar.createEvents(events);
   }
 
-  describe('eventFilter option', () => {
-    beforeEach(() => {
-      jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
-        x: 0,
-        y: 0,
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0,
-        width: 100,
-        height: 100,
-        toJSON: noop,
-      });
+  return render(<Month />, { store });
+}
+
+describe('eventFilter option', () => {
+  beforeAll(() => {
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      width: 100,
+      height: 100,
+      toJSON: noop,
     });
+  });
 
-    const events: EventModel[] = [];
-    for (let i = 0; i < 2; i += 1) {
-      events.push(
-        EventModel.create({
-          id: `${i}`,
-          title: `Event ${i}`,
-          start: new TZDate().addMinutes(60 * i),
-          end: new TZDate().addMinutes(60 * i + 30),
-          isVisible: !!(i % 2),
-        })
-      );
-    }
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
 
-    it('should show only the events which of isVisible is true when the eventFilter option is not specified.', () => {
-      // Given
-      setup({}, events);
+  const events: EventModel[] = [];
+  for (let i = 0; i < 2; i += 1) {
+    events.push(
+      EventModel.create({
+        id: `${i}`,
+        title: `Event ${i}`,
+        start: new TZDate().addMinutes(60 * i),
+        end: new TZDate().addMinutes(60 * i + 30),
+        isVisible: !!(i % 2),
+      })
+    );
+  }
 
-      // When
-      // Nothing
+  it('should show only the events which of isVisible is true when the eventFilter option is not specified.', () => {
+    // Given
+    setup({}, events);
 
-      // Then
-      const visibleEvent = events.find((event) => event.isVisible) as EventModel;
-      const invisibleEvent = events.find((event) => !event.isVisible) as EventModel;
-      expect(screen.queryByText(visibleEvent.title)).toBeInTheDocument();
-      expect(screen.queryByText(invisibleEvent.title)).not.toBeInTheDocument();
-    });
+    // When
+    // Nothing
 
-    it('should show only the events that pass the eventFilter function.', () => {
-      // Given
-      const eventFilter = (event: EventModelData) => !!(Number(event.id) % 2);
-      setup({ eventFilter }, events);
+    // Then
+    const visibleEvent = events.find((event) => event.isVisible) as EventModel;
+    const invisibleEvent = events.find((event) => !event.isVisible) as EventModel;
+    expect(screen.queryByText(visibleEvent.title)).toBeInTheDocument();
+    expect(screen.queryByText(invisibleEvent.title)).not.toBeInTheDocument();
+  });
 
-      // When
-      // Nothing
+  it('should show only the events that pass the eventFilter function.', () => {
+    // Given
+    const eventFilter = (event: EventModelData) => !!(Number(event.id) % 2);
+    setup({ eventFilter }, events);
 
-      // Then
-      const visibleEvent = events.find(eventFilter) as EventModel;
-      const invisibleEvent = events.find((event) => !eventFilter(event)) as EventModel;
-      expect(screen.queryByText(visibleEvent.title)).toBeInTheDocument();
-      expect(screen.queryByText(invisibleEvent.title)).not.toBeInTheDocument();
-    });
+    // When
+    // Nothing
+
+    // Then
+    const visibleEvent = events.find(eventFilter) as EventModel;
+    const invisibleEvent = events.find((event) => !eventFilter(event)) as EventModel;
+    expect(screen.queryByText(visibleEvent.title)).toBeInTheDocument();
+    expect(screen.queryByText(invisibleEvent.title)).not.toBeInTheDocument();
   });
 });

--- a/apps/calendar/src/components/view/month.tsx
+++ b/apps/calendar/src/components/view/month.tsx
@@ -65,12 +65,7 @@ export function Month() {
         rowStyleInfo={rowStyleInfo}
         type="month"
       />
-      <DayGridMonth
-        options={monthOptions}
-        dateMatrix={dateMatrix}
-        rowInfo={rowInfo}
-        cellWidthMap={cellWidthMap}
-      />
+      <DayGridMonth dateMatrix={dateMatrix} rowInfo={rowInfo} cellWidthMap={cellWidthMap} />
     </Layout>
   );
 }

--- a/apps/calendar/src/components/view/week.spec.tsx
+++ b/apps/calendar/src/components/view/week.spec.tsx
@@ -1,17 +1,25 @@
 import { h } from 'preact';
 
+import { screen } from '@testing-library/preact';
+
 import { Week } from '@src/components/view/week';
 import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
 import { initCalendarStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
 import { getActivePanels } from '@src/helpers/view';
+import EventModel from '@src/model/eventModel';
 import { render } from '@src/test/utils';
+import TZDate from '@src/time/date';
 
-import type { WeekOptions } from '@t/options';
+import type { EventModelData } from '@t/events';
+import type { Options, WeekOptions } from '@t/options';
 
 describe('week', () => {
-  function setup(weekOptions: WeekOptions) {
-    const store = initCalendarStore({ week: weekOptions });
+  function setup(options: Options, events?: EventModel[]) {
+    const store = initCalendarStore(options);
+    if (events) {
+      store.getState().dispatch.calendar.createEvents(events);
+    }
 
     return render(<Week />, { store });
   }
@@ -30,7 +38,7 @@ describe('week', () => {
       'should show/hide the panels in the daily view: { eventView: $eventView, taskView: $eventView }',
       (weekOptions) => {
         // Given
-        const { container } = setup(weekOptions);
+        const { container } = setup({ week: weekOptions });
 
         // When
         // Nothing
@@ -50,5 +58,49 @@ describe('week', () => {
         });
       }
     );
+  });
+
+  describe('eventFilter option', () => {
+    const events: EventModel[] = [];
+    for (let i = 0; i < 2; i += 1) {
+      events.push(
+        EventModel.create({
+          id: `${i}`,
+          title: `Event ${i}`,
+          start: new TZDate().addMinutes(60 * i),
+          end: new TZDate().addMinutes(60 * i + 30),
+          isVisible: !!(i % 2),
+        })
+      );
+    }
+
+    it('should show only the events which of isVisible is true when the eventFilter option is not specified.', () => {
+      // Given
+      setup({}, events);
+
+      // When
+      // Nothing
+
+      // Then
+      const visibleEvent = events.find((event) => event.isVisible) as EventModel;
+      const invisibleEvent = events.find((event) => !event.isVisible) as EventModel;
+      expect(screen.queryByText(visibleEvent.title)).toBeInTheDocument();
+      expect(screen.queryByText(invisibleEvent.title)).not.toBeInTheDocument();
+    });
+
+    it('should show only the events that pass the eventFilter function.', () => {
+      // Given
+      const eventFilter = (event: EventModelData) => !!(Number(event.id) % 2);
+      setup({ eventFilter }, events);
+
+      // When
+      // Nothing
+
+      // Then
+      const visibleEvent = events.find(eventFilter) as EventModel;
+      const invisibleEvent = events.find((event) => !eventFilter(event)) as EventModel;
+      expect(screen.queryByText(visibleEvent.title)).toBeInTheDocument();
+      expect(screen.queryByText(invisibleEvent.title)).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -11,9 +11,9 @@ import { WEEK_DAYNAME_BORDER, WEEK_DAYNAME_HEIGHT } from '@src/constants/style';
 import { useStore } from '@src/contexts/calendarStore';
 import { cls } from '@src/helpers/css';
 import { getDayNames } from '@src/helpers/dayName';
-import { getVisibleEventCollection } from '@src/helpers/events';
 import { createTimeGridData, getDayGridEvents, getWeekDates } from '@src/helpers/grid';
 import { getActivePanels } from '@src/helpers/view';
+import { useCalendarData } from '@src/hooks/calendar/useCalendarData';
 import { useDOMNode } from '@src/hooks/common/useDOMNode';
 import { useTimeGridScrollSync } from '@src/hooks/timeGrid/useTimeGridScrollSync';
 import {
@@ -60,13 +60,7 @@ export function Week() {
     startDayOfWeek,
     workweek
   );
-  const calendarData = useMemo(
-    () => ({
-      ...calendar,
-      events: getVisibleEventCollection(calendar.events),
-    }),
-    [calendar]
-  );
+  const calendarData = useCalendarData(calendar, options.eventFilter);
   const eventByPanel = useMemo(
     () =>
       getDayGridEvents(weekDates, calendarData, {

--- a/apps/calendar/src/helpers/events.ts
+++ b/apps/calendar/src/helpers/events.ts
@@ -59,9 +59,3 @@ export function isSameEvent(event: EventModel, eventId: string, calendarId: stri
 export function isVisibleEvent(event: EventModel) {
   return event.isVisible;
 }
-
-export function getVisibleEventCollection(events: Collection<EventModel>) {
-  const visibleEvents = events.toArray().filter((eventModel) => eventModel.isVisible);
-
-  return createEventCollection<EventModel>(...visibleEvents);
-}

--- a/apps/calendar/src/helpers/view.ts
+++ b/apps/calendar/src/helpers/view.ts
@@ -1,12 +1,12 @@
 import { DEFAULT_EVENT_PANEL, DEFAULT_TASK_PANEL } from '@src/constants/view';
 
-import type { WeekOptions } from '@t/options';
+import type { EventView, TaskView, WeekOptions } from '@t/options';
 
 export function getActivePanels(
   taskView: Required<WeekOptions>['taskView'],
   eventView: Required<WeekOptions>['eventView']
-) {
-  const activePanels: string[] = [];
+): (TaskView | EventView)[] {
+  const activePanels: (TaskView | EventView)[] = [];
 
   if (taskView === true) {
     activePanels.push(...DEFAULT_TASK_PANEL);

--- a/apps/calendar/src/hooks/calendar/useCalendarData.ts
+++ b/apps/calendar/src/hooks/calendar/useCalendarData.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'preact/hooks';
+
+import type EventModel from '@src/model/eventModel';
+import type { Filter } from '@src/utils/collection';
+import Collection from '@src/utils/collection';
+
+import type { CalendarData } from '@t/events';
+
+export function useCalendarData(calendar: CalendarData, ...filters: Filter<EventModel>[]) {
+  return useMemo(
+    () => ({
+      ...calendar,
+      events: calendar.events.filter(Collection.and<EventModel>(...filters)),
+    }),
+    [calendar, filters]
+  );
+}

--- a/apps/calendar/src/slices/options.ts
+++ b/apps/calendar/src/slices/options.ts
@@ -57,8 +57,6 @@ function initializeMonthOptions(monthOptions: Options['month']): CalendarMonthOp
       footer: { height: 31 },
     },
     visibleEventCount: 6,
-    eventFilter: (event: Required<EventModelData>) =>
-      event.isVisible && ['allday', 'time'].includes(event.category),
     ...monthOptions,
   };
 
@@ -86,6 +84,9 @@ export function initializeGridSelectionOptions(
   };
 }
 
+const initialEventFilter = (event: EventModelData) =>
+  !!(event.isVisible && ['allday', 'time'].includes(event.category || ''));
+
 // @TODO: some of options has default values. so it should be `Required` type.
 // But it needs a complex type such as `DeepRequired`.
 // maybe leveraging library like `ts-essential` might be helpful.
@@ -111,6 +112,7 @@ export function createOptionsSlice(options: Options = {}): OptionsSlice {
       month: initializeMonthOptions(options.month),
       gridSelection: initializeGridSelectionOptions(options.gridSelection),
       usageStatistics: options.usageStatistics ?? true,
+      eventFilter: options.eventFilter ?? initialEventFilter,
     },
   };
 }

--- a/apps/calendar/src/slices/options.ts
+++ b/apps/calendar/src/slices/options.ts
@@ -84,8 +84,7 @@ export function initializeGridSelectionOptions(
   };
 }
 
-const initialEventFilter = (event: EventModelData) =>
-  !!(event.isVisible && ['allday', 'time'].includes(event.category || ''));
+const initialEventFilter = (event: EventModelData) => !!event.isVisible;
 
 // @TODO: some of options has default values. so it should be `Required` type.
 // But it needs a complex type such as `DeepRequired`.

--- a/apps/calendar/stories/dayGridMonth.stories.tsx
+++ b/apps/calendar/stories/dayGridMonth.stories.tsx
@@ -42,7 +42,7 @@ export const Week = () => {
 };
 
 export const Month = () => {
-  const options: CalendarMonthOptions = {
+  const monthOptions: CalendarMonthOptions = {
     visibleWeeksCount: 3,
     workweek: false,
     narrowWeekend: false,
@@ -57,13 +57,13 @@ export const Month = () => {
     visibleEventCount: 6,
   };
 
-  const dateMatrix = createDateMatrixOfMonth(new Date(), options);
+  const dateMatrix = createDateMatrixOfMonth(new Date(), monthOptions);
 
   const { rowStyleInfo, cellWidthMap } = getRowStyleInfo(
     dateMatrix[0].length,
-    options.narrowWeekend,
-    options.startDayOfWeek,
-    options.workweek
+    monthOptions.narrowWeekend,
+    monthOptions.startDayOfWeek,
+    monthOptions.workweek
   );
 
   const rowInfo = rowStyleInfo.map((cellStyleInfo, index) => ({
@@ -74,12 +74,7 @@ export const Month = () => {
   return (
     <ProviderWrapper>
       <Layout>
-        <DayGridMonth
-          options={options}
-          dateMatrix={dateMatrix}
-          rowInfo={rowInfo}
-          cellWidthMap={cellWidthMap}
-        />
+        <DayGridMonth dateMatrix={dateMatrix} rowInfo={rowInfo} cellWidthMap={cellWidthMap} />
       </Layout>
     </ProviderWrapper>
   );

--- a/apps/calendar/stories/dayGridMonth.stories.tsx
+++ b/apps/calendar/stories/dayGridMonth.stories.tsx
@@ -55,7 +55,6 @@ export const Month = () => {
       footer: { height: 31 },
     },
     visibleEventCount: 6,
-    eventFilter: () => true,
   };
 
   const dateMatrix = createDateMatrixOfMonth(new Date(), options);

--- a/apps/calendar/types/options.d.ts
+++ b/apps/calendar/types/options.d.ts
@@ -44,7 +44,6 @@ export interface MonthOptions {
       height?: number;
     };
   };
-  eventFilter?: (event: Required<EventModelData>) => boolean;
 }
 
 export interface GridSelectionOptions {
@@ -93,6 +92,7 @@ export interface Options {
   isReadOnly?: boolean;
   usageStatistics?: boolean;
   timezone?: CustomTimezone;
+  eventFilter?: (event: EventModelData) => boolean;
 }
 
 interface ViewInfoUserInput {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description


* [BREAKING CHANGE] `month.eventFilter` option is deprecated.
  * Instead, use `eventFilter`.
  ```js
  const options = {
    // month: { eventFilter: (event) => event.isVisible }, // deprecated
    eventFilter: (event) => event.isVisible
  };
  ```
  * The default value is `(event: EventModelData) => !!(event.isVisible && ['allday', 'time'].includes(event.category || ''));`.
  * If the `eventFilter` option is specified, original event filter is overwritten.
* Implement the `eventFilter` option.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
