### PR TITLE
feat: implement `afterRenderEvent` instance event

### DIFF
--- a/apps/calendar/src/components/events/horizontalEvent.spec.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.spec.tsx
@@ -1,0 +1,78 @@
+import { h } from 'preact';
+
+import { HorizontalEvent } from '@src/components/events/horizontalEvent';
+import EventModel from '@src/model/eventModel';
+import EventUIModel from '@src/model/eventUIModel';
+import { render } from '@src/test/utils';
+import { EventBusImpl } from '@src/utils/eventBus';
+
+import type { ExternalEventTypes } from '@t/eventBus';
+
+describe(`Firing 'afterRenderEvent'`, () => {
+  function setup() {
+    const eventBus = new EventBusImpl<ExternalEventTypes>();
+    const handler = jest.fn();
+    eventBus.on('afterRenderEvent', handler);
+    const uiModel = EventUIModel.create(
+      EventModel.create({
+        id: '1',
+        start: new Date(2020, 0, 1, 10, 0),
+        end: new Date(2020, 0, 1, 12, 0),
+      })
+    );
+    const props = {
+      uiModel,
+      eventHeight: 30,
+      headerHeight: 0,
+    };
+
+    return {
+      props,
+      eventBus,
+      handler,
+    };
+  }
+
+  it(`should fire 'afterRenderEvent' when only the component is mounted`, () => {
+    // Given
+    const { props, eventBus, handler } = setup();
+
+    // When
+    const { rerender } = render(<HorizontalEvent {...props} />, { eventBus });
+
+    // Then
+    expect(handler).toBeCalledWith(props.uiModel.model);
+
+    // When rerender
+    handler.mockReset();
+    rerender(<HorizontalEvent {...props} />);
+
+    // Then
+    expect(handler).not.toBeCalled();
+  });
+
+  it(`should not fire 'afterRenderEvent' when the component is working as a drag & drop interaction guide element`, () => {
+    // Given
+    const { props, eventBus, handler } = setup();
+    const propsWithResizingWidth = {
+      ...props,
+      resizingWidth: '100px',
+    };
+    const propsWithMovingLeft = {
+      ...props,
+      movingLeft: 100,
+    };
+
+    // When (resizingWidth)
+    const { rerender } = render(<HorizontalEvent {...propsWithResizingWidth} />, { eventBus });
+
+    // Then
+    expect(handler).not.toBeCalled();
+
+    // When (movingLeft)
+    rerender(<HorizontalEvent {...propsWithMovingLeft} />);
+
+    // Then
+    expect(handler).not.toBeCalled();
+  });
+});

--- a/apps/calendar/src/components/events/horizontalEvent.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.tsx
@@ -197,7 +197,9 @@ export function HorizontalEvent({
     if (isDraggableEvent) {
       eventBus.fire('afterRenderEvent', uiModel.model);
     }
-  }, [eventBus, uiModel.model, isDraggableEvent]);
+    // This effect is only for the first render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onResizeStart = useDrag(DRAGGING_TYPE_CREATORS.resizeEvent('dayGrid', `${uiModel.cid()}`), {
     onDragStart: () => startDragEvent(classNames.resizeEvent),

--- a/apps/calendar/src/components/events/timeEvent.spec.tsx
+++ b/apps/calendar/src/components/events/timeEvent.spec.tsx
@@ -1,0 +1,64 @@
+import { h } from 'preact';
+
+import { TimeEvent } from '@src/components/events/timeEvent';
+import EventModel from '@src/model/eventModel';
+import EventUIModel from '@src/model/eventUIModel';
+import { render } from '@src/test/utils';
+import TZDate from '@src/time/date';
+import { EventBusImpl } from '@src/utils/eventBus';
+
+import type { ExternalEventTypes } from '@t/eventBus';
+
+describe(`Firing 'afterRenderEvent'`, () => {
+  function setup() {
+    const eventBus = new EventBusImpl<ExternalEventTypes>();
+    const handler = jest.fn();
+    eventBus.on('afterRenderEvent', handler);
+    const uiModel = EventUIModel.create(
+      EventModel.create({
+        id: '1',
+        start: new Date('2022-05-19T09:00:00'),
+        end: new Date('2022-05-19T10:00:00'),
+      })
+    );
+    const props = {
+      uiModel,
+      nextStartTime: new TZDate('2022-05-19T11:00:00'),
+    };
+
+    return {
+      props,
+      eventBus,
+      handler,
+    };
+  }
+
+  it(`should fire 'afterRenderEvent' when only the component is mounted`, () => {
+    // Given
+    const { props, eventBus, handler } = setup();
+
+    // When
+    const { rerender } = render(<TimeEvent {...props} />, { eventBus });
+
+    // Then
+    expect(handler).toBeCalledWith(props.uiModel.model);
+
+    // When (re-render)
+    handler.mockReset();
+    rerender(<TimeEvent {...props} />);
+
+    // Then
+    expect(handler).not.toBeCalled();
+  });
+
+  it(`should not fire 'afterRenderEvent' when the component is working as a drag & drop interaction guide element`, () => {
+    // Given
+    const { props, eventBus, handler } = setup();
+
+    // When
+    render(<TimeEvent {...props} isResizingGuide={true} />, { eventBus });
+
+    // Then
+    expect(handler).not.toBeCalled();
+  });
+});

--- a/apps/calendar/src/components/events/timeEvent.tsx
+++ b/apps/calendar/src/components/events/timeEvent.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useRef, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { Template } from '@src/components/template';
 import { useDispatch, useStore } from '@src/contexts/calendarStore';
@@ -129,6 +129,14 @@ export function TimeEvent({ uiModel, nextStartTime, isResizingGuide = false }: P
       setIsDraggingTarget(false);
     }
   });
+
+  useEffect(() => {
+    if (!isResizingGuide) {
+      eventBus.fire('afterRenderEvent', uiModel.model);
+    }
+    // This effect is only for the first render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const startDragEvent = (className: string) => {
     setDraggingEventUIModel(uiModel);

--- a/apps/calendar/src/test/utils.tsx
+++ b/apps/calendar/src/test/utils.tsx
@@ -20,13 +20,13 @@ import type { FormattedTimeString } from '@t/time/datetime';
 function render(
   component: Parameters<typeof ptlRender>[0],
   {
-    eventBus = new EventBusImpl<any>(),
+    eventBus = new EventBusImpl<Record<string, any>>(),
     store = initCalendarStore(),
     theme = initThemeStore(),
     ...options
   }: Parameters<typeof ptlRender>[1] &
     Partial<{
-      eventBus: EventBus<any>;
+      eventBus: EventBus<Record<string, any>>;
       store: InternalStoreAPI<CalendarStore>;
       theme: InternalStoreAPI<ThemeStore>;
     }> = {}

--- a/apps/calendar/types/eventBus.d.ts
+++ b/apps/calendar/types/eventBus.d.ts
@@ -35,6 +35,7 @@ type ExternalEventTypes = {
   beforeCreateEvent: (event: EventModelData) => void;
   beforeUpdateEvent: (updatedEventInfo: UpdatedEventInfo) => void;
   beforeDeleteEvent: (event: EventModel) => void;
+  afterRenderEvent: (event: EventModel) => void;
   clickDayname: (daynameInfo: DaynameInfo) => void;
   clickEvent: (eventInfo: EventInfo) => void;
   clickMoreEventsBtn: (moreEventsBtnInfo: MoreEventsButton) => void;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Fire `afterRenderEvent` when event components are mounted.
  - This really doesn't need to disable the ESLint rule, but just in case.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
