### PR TITLE
fix: set TimezoneLabels' top position correctly and implement TimezoneLabels in the day view

### DIFF
--- a/apps/calendar/src/components/view/day.tsx
+++ b/apps/calendar/src/components/view/day.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useCallback, useLayoutEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useMemo } from 'preact/hooks';
 
 import { GridHeader } from '@src/components/dayGridCommon/gridHeader';
 import { AlldayGridRow } from '@src/components/dayGridWeek/alldayGridRow';
@@ -18,6 +18,7 @@ import { getActivePanels } from '@src/helpers/view';
 import { useCalendarData } from '@src/hooks/calendar/useCalendarData';
 import { useDOMNode } from '@src/hooks/common/useDOMNode';
 import { useTimeGridScrollSync } from '@src/hooks/timeGrid/useTimeGridScrollSync';
+import { useTimezoneLabelsTop } from '@src/hooks/timeGrid/useTimezoneLabelsTop';
 import {
   calendarSelector,
   optionsSelector,
@@ -25,11 +26,9 @@ import {
   weekViewLayoutSelector,
 } from '@src/selectors';
 import { getRowStyleInfo } from '@src/time/datetime';
-import { isPresent } from '@src/utils/type';
 
 import type { WeekOptions } from '@t/options';
 import type { AlldayEventCategory } from '@t/panel';
-import type { CalendarState } from '@t/store';
 
 function useDayViewState() {
   const calendar = useStore(calendarSelector);
@@ -49,17 +48,9 @@ function useDayViewState() {
   );
 }
 
-function timegridHeightSelector(state: CalendarState) {
-  // TODO: change `dayGridRows` to `panels`
-  return state.weekViewLayout?.dayGridRows?.time?.height;
-}
-
 export function Day() {
   const { calendar, options, gridRowLayout, lastPanelType, renderDate } = useDayViewState();
-  const timeGridPanelHeight = useStore(timegridHeightSelector);
   const gridHeaderMarginLeft = useTheme(useCallback((theme) => theme.week.dayGridLeft.width, []));
-
-  const [stickyTop, setStickyTop] = useState<number | null>(null);
   const [timePanel, setTimePanelRef] = useDOMNode<HTMLDivElement>();
 
   const weekOptions = options.week as Required<WeekOptions>;
@@ -122,17 +113,7 @@ export function Day() {
 
   useTimeGridScrollSync(timePanel, timeGridData.rows.length);
 
-  useLayoutEffect(() => {
-    const updateStickyTop = () => {
-      if (timePanel) {
-        setStickyTop(timePanel.offsetTop);
-      }
-    };
-
-    if (isPresent(timeGridPanelHeight)) {
-      updateStickyTop();
-    }
-  }, [timeGridPanelHeight, timePanel]);
+  const stickyTop = useTimezoneLabelsTop(timePanel);
 
   return (
     <Layout className={cls('day-view')} autoAdjustPanels={true}>

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -131,8 +131,7 @@ export function Week() {
   useLayoutEffect(() => {
     const updateStickyTop = () => {
       if (timePanel) {
-        const { top } = timePanel.getBoundingClientRect();
-        setStickyTop(top);
+        setStickyTop(timePanel.offsetTop);
       }
     };
 

--- a/apps/calendar/src/components/view/week.tsx
+++ b/apps/calendar/src/components/view/week.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useCallback, useLayoutEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useMemo } from 'preact/hooks';
 
 import { GridHeader } from '@src/components/dayGridCommon/gridHeader';
 import { AlldayGridRow } from '@src/components/dayGridWeek/alldayGridRow';
@@ -18,6 +18,7 @@ import { getActivePanels } from '@src/helpers/view';
 import { useCalendarData } from '@src/hooks/calendar/useCalendarData';
 import { useDOMNode } from '@src/hooks/common/useDOMNode';
 import { useTimeGridScrollSync } from '@src/hooks/timeGrid/useTimeGridScrollSync';
+import { useTimezoneLabelsTop } from '@src/hooks/timeGrid/useTimezoneLabelsTop';
 import {
   calendarSelector,
   optionsSelector,
@@ -25,11 +26,9 @@ import {
   weekViewLayoutSelector,
 } from '@src/selectors';
 import { getRowStyleInfo } from '@src/time/datetime';
-import { isPresent } from '@src/utils/type';
 
 import type { WeekOptions } from '@t/options';
 import type { AlldayEventCategory } from '@t/panel';
-import type { CalendarState } from '@t/store';
 
 function useWeekViewState() {
   const options = useStore(optionsSelector);
@@ -49,17 +48,10 @@ function useWeekViewState() {
   );
 }
 
-function timegridHeightSelector(state: CalendarState) {
-  // TODO: change `dayGridRows` to `panels`
-  return state.weekViewLayout?.dayGridRows?.time?.height;
-}
-
 export function Week() {
   const { options, calendar, gridRowLayout, lastPanelType, renderDate } = useWeekViewState();
-  const timeGridPanelHeight = useStore(timegridHeightSelector);
   const gridHeaderMarginLeft = useTheme(useCallback((theme) => theme.week.dayGridLeft.width, []));
 
-  const [stickyTop, setStickyTop] = useState<number | null>(null);
   const [timePanel, setTimePanelRef] = useDOMNode<HTMLDivElement>();
 
   const weekOptions = options.week as Required<WeekOptions>;
@@ -128,17 +120,7 @@ export function Week() {
 
   useTimeGridScrollSync(timePanel, timeGridData.rows.length);
 
-  useLayoutEffect(() => {
-    const updateStickyTop = () => {
-      if (timePanel) {
-        setStickyTop(timePanel.offsetTop);
-      }
-    };
-
-    if (isPresent(timeGridPanelHeight)) {
-      updateStickyTop();
-    }
-  }, [timeGridPanelHeight, timePanel]);
+  const stickyTop = useTimezoneLabelsTop(timePanel);
 
   return (
     <Layout className={cls('week-view')} autoAdjustPanels={true}>

--- a/apps/calendar/src/hooks/timeGrid/useTimezoneLabelsTop.ts
+++ b/apps/calendar/src/hooks/timeGrid/useTimezoneLabelsTop.ts
@@ -1,0 +1,24 @@
+import { useLayoutEffect, useState } from 'preact/hooks';
+
+import { useStore } from '@src/contexts/calendarStore';
+import { isPresent } from '@src/utils/type';
+
+import type { CalendarState } from '@t/store';
+
+function timegridHeightSelector(state: CalendarState) {
+  // TODO: change `dayGridRows` to `panels`
+  return state.weekViewLayout?.dayGridRows?.time?.height;
+}
+
+export function useTimezoneLabelsTop(timePanel: HTMLDivElement | null): number | null {
+  const timeGridPanelHeight = useStore(timegridHeightSelector);
+  const [stickyTop, setStickyTop] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (isPresent(timeGridPanelHeight) && timePanel) {
+      setStickyTop(timePanel.offsetTop);
+    }
+  }, [timeGridPanelHeight, timePanel]);
+
+  return stickyTop;
+}

--- a/apps/calendar/stories/e2e/day.stories.tsx
+++ b/apps/calendar/stories/e2e/day.stories.tsx
@@ -36,3 +36,36 @@ ReadOnly.args = {
   },
   onInit: FixedEvents.args.onInit,
 };
+
+export const MultipleTimezones = Template.bind({});
+MultipleTimezones.args = {
+  ...Template.args,
+  options: {
+    ...Template.args.options,
+    week: {
+      showTimezoneCollapseButton: true,
+    },
+    theme: {
+      week: {
+        dayGridLeft: {
+          width: '120px',
+        },
+        timeGridLeft: {
+          width: '120px',
+        },
+      },
+    },
+    timezone: {
+      zones: [
+        {
+          timezoneName: 'Asia/Karachi',
+          displayLabel: '+05:00',
+        },
+        {
+          timezoneName: 'US/Samoa',
+          displayLabel: '-11:00',
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

* Set TimezoneLabels top position to TimePanel's offsetTop
  * before
    * ![image](https://user-images.githubusercontent.com/8615506/172580519-2aaa7c62-cd3a-4bb0-9d3e-a083611b1fda.png)
  * after
    * ![image](https://user-images.githubusercontent.com/8615506/172580775-16577356-5530-427b-823a-f9801e224ba0.png)
* Implement TimezoneLabels in the day view

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
