### PR TITLE
feat: pass grid selection elements when `selectDateTime` custom event is fired

### DIFF
--- a/apps/calendar/docs/ko/apis/calendar.stories.mdx
+++ b/apps/calendar/docs/ko/apis/calendar.stories.mdx
@@ -756,12 +756,13 @@ interface SelectDateTimeInfo {
   end: Date;
   isAllday: boolean;
   nativeEvent?: MouseEvent; // 마우스를 떼었을 때의 네이티브 이벤트
+  gridSelectionElements: NodeList; // 선택 영역에 해당하는 엘리먼트 목록
 }
 ```
 
 캘린더 인스턴스 옵션 중 `isReadOnly` 가 `false` 일 때, 캘린더 영역의 빈 공간을 클릭하거나 드래그 앤 드랍 했을 경우 특정 날짜 혹은 시간을 선택할 수 있다.
 
-이 때 `selectDateTime` 이벤트를 통해 선택된 시간의 정보를 얻을 수 있다.
+이 때 `selectDateTime` 이벤트를 통해 선택된 시간의 정보를 얻을 수 있다. `gridSelectionElements`를 통해 엘리먼트를 직접 활용하여 위치 계산 등을 할 수 있도록 돕는다.
 
 ![월간 뷰에서 날짜 선택](./select-date-time-1.gif)
 ![주간 / 일간 뷰에서 시간 선택](./select-date-time-2.gif)

--- a/apps/calendar/playwright/assertions.ts
+++ b/apps/calendar/playwright/assertions.ts
@@ -60,7 +60,7 @@ export async function assertAccumulatedDayGridSelectionMatching(
 ) {
   const cellClassName = '.toastui-calendar-daygrid-cell';
   const selectionClassName =
-    '.toastui-calendar-accumulated-grid-selection .toastui-calendar-daygrid-grid-selection';
+    '.toastui-calendar-accumulated-grid-selection .toastui-calendar-grid-selection';
 
   const startCellLocator = page.locator(cellClassName).nth(startIdx);
   const endCellLocator = page.locator(cellClassName).nth(endIdx);

--- a/apps/calendar/playwright/month/accumulatedGridSelection.e2e.ts
+++ b/apps/calendar/playwright/month/accumulatedGridSelection.e2e.ts
@@ -13,7 +13,6 @@ test('select 2 cells in each week', async ({ page }) => {
   await selectMonthGridCells(page, 28, 30);
 
   await assertAccumulatedDayGridSelectionMatching(page, 21, 23, 0, false);
-  await assertAccumulatedDayGridSelectionMatching(page, 28, 30, 1, false);
 });
 
 test('select 2 cells across 2 weeks', async ({ page }) => {
@@ -21,7 +20,6 @@ test('select 2 cells across 2 weeks', async ({ page }) => {
   await selectMonthGridCells(page, 20, 21);
 
   await assertAccumulatedDayGridSelectionMatching(page, 13, 14, 0, true);
-  await assertAccumulatedDayGridSelectionMatching(page, 20, 21, 2, true);
 });
 
 test('select cell across 2 weeks and select cell in 1 week', async ({ page }) => {
@@ -29,5 +27,4 @@ test('select cell across 2 weeks and select cell in 1 week', async ({ page }) =>
   await selectMonthGridCells(page, 24, 25);
 
   await assertAccumulatedDayGridSelectionMatching(page, 13, 14, 0, true);
-  await assertAccumulatedDayGridSelectionMatching(page, 24, 25, 2, false);
 });

--- a/apps/calendar/playwright/month/gridSelection.e2e.ts
+++ b/apps/calendar/playwright/month/gridSelection.e2e.ts
@@ -12,7 +12,7 @@ test.beforeEach(async ({ page }) => {
 
 const MONTH_GRID_CELL_SELECTOR = getPrefixedClassName('daygrid-cell');
 const GRID_SELECTION_SELECTOR = `${getPrefixedClassName('weekday')} > ${getPrefixedClassName(
-  'daygrid-grid-selection'
+  'grid-selection'
 )}`;
 
 /**

--- a/apps/calendar/playwright/week/dayGridSelection.e2e.ts
+++ b/apps/calendar/playwright/week/dayGridSelection.e2e.ts
@@ -11,7 +11,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 const WEEK_GRID_CELL_SELECTOR = getPrefixedClassName('panel-grid');
-const DAY_GRID_SELECTION_SELECTOR = getPrefixedClassName('daygrid-grid-selection');
+const DAY_GRID_SELECTION_SELECTOR = getPrefixedClassName('grid-selection');
 
 function selectWeekGridCells(page: Page, startCellIndex: number, endCellIndex: number) {
   return selectGridCells(page, startCellIndex, endCellIndex, WEEK_GRID_CELL_SELECTOR);

--- a/apps/calendar/src/components/dayGridCommon/gridSelection.tsx
+++ b/apps/calendar/src/components/dayGridCommon/gridSelection.tsx
@@ -9,6 +9,7 @@ import type { GridSelectionDataByRow } from '@t/components/gridSelection';
 import type { ThemeState } from '@t/theme';
 
 interface Props {
+  type: 'allday' | 'month' | 'accumulated';
   gridSelectionData: GridSelectionDataByRow;
   weekDates: TZDate[];
   narrowWeekend: boolean;
@@ -18,7 +19,7 @@ function commonGridSelectionSelector(theme: ThemeState) {
   return theme.common.gridSelection;
 }
 
-export function GridSelection({ gridSelectionData, weekDates, narrowWeekend }: Props) {
+export function GridSelection({ type, gridSelectionData, weekDates, narrowWeekend }: Props) {
   const { backgroundColor, border } = useTheme(commonGridSelectionSelector);
   const { startCellIndex, endCellIndex } = gridSelectionData;
 
@@ -37,5 +38,5 @@ export function GridSelection({ gridSelectionData, weekDates, narrowWeekend }: P
     border,
   };
 
-  return width > 0 ? <div className={cls('grid-selection')} style={style} /> : null;
+  return width > 0 ? <div className={cls(type, 'grid-selection')} style={style} /> : null;
 }

--- a/apps/calendar/src/components/dayGridCommon/gridSelection.tsx
+++ b/apps/calendar/src/components/dayGridCommon/gridSelection.tsx
@@ -37,5 +37,5 @@ export function GridSelection({ gridSelectionData, weekDates, narrowWeekend }: P
     border,
   };
 
-  return width > 0 ? <div className={cls('daygrid-grid-selection')} style={style} /> : null;
+  return width > 0 ? <div className={cls('grid-selection')} style={style} /> : null;
 }

--- a/apps/calendar/src/components/dayGridMonth/accumulatedGridSelection.tsx
+++ b/apps/calendar/src/components/dayGridMonth/accumulatedGridSelection.tsx
@@ -29,6 +29,7 @@ export function AccumulatedGridSelection({ rowIndex, weekDates, narrowWeekend }:
       {gridSelectionDataByRow.map((gridSelectionData) =>
         gridSelectionData ? (
           <GridSelection
+            type="accumulated"
             gridSelectionData={gridSelectionData}
             weekDates={weekDates}
             narrowWeekend={narrowWeekend}

--- a/apps/calendar/src/components/dayGridMonth/gridSelectionByRow.tsx
+++ b/apps/calendar/src/components/dayGridMonth/gridSelectionByRow.tsx
@@ -34,6 +34,7 @@ export function GridSelectionByRow({ weekDates, narrowWeekend, rowIndex }: Props
 
   return (
     <GridSelection
+      type="month"
       gridSelectionData={gridSelectionDataByRow}
       weekDates={weekDates}
       narrowWeekend={narrowWeekend}

--- a/apps/calendar/src/components/dayGridWeek/alldayGridSelection.tsx
+++ b/apps/calendar/src/components/dayGridWeek/alldayGridSelection.tsx
@@ -26,6 +26,7 @@ export function AlldayGridSelection({ weekDates, narrowWeekend }: Props) {
 
   return (
     <GridSelection
+      type="allday"
       gridSelectionData={calculatedGridSelection}
       weekDates={weekDates}
       narrowWeekend={narrowWeekend}

--- a/apps/calendar/src/components/timeGrid/gridSelectionByColumn.tsx
+++ b/apps/calendar/src/components/timeGrid/gridSelectionByColumn.tsx
@@ -25,7 +25,7 @@ function GridSelection({ top, height, text }: { top: number; height: number; tex
 
   return (
     <div
-      className={cls('grid-selection')}
+      className={cls('time', 'grid-selection')}
       style={style}
       data-testid={`time-grid-selection-${top}-${height}`}
     >

--- a/apps/calendar/src/css/daygrid/dayGrid.css
+++ b/apps/calendar/src/css/daygrid/dayGrid.css
@@ -77,6 +77,6 @@
   height: 100%;
 }
 
-.weekday .daygrid-grid-selection {
+.weekday .grid-selection {
   position: absolute;
 }

--- a/apps/calendar/src/css/panel/allday.css
+++ b/apps/calendar/src/css/panel/allday.css
@@ -28,7 +28,7 @@
   overflow-y: hidden;
 }
 
-.allday-panel .daygrid-grid-selection {
+.allday-panel .grid-selection {
   position: absolute;
   right: 10px;
   z-index: 1;

--- a/apps/calendar/src/hooks/gridSelection/useGridSelection.spec.tsx
+++ b/apps/calendar/src/hooks/gridSelection/useGridSelection.spec.tsx
@@ -362,6 +362,7 @@ describe('useGridSelection', () => {
 
       // When
       dragAndDrop({ element: container, initPosition, targetPosition });
+      dragAndDrop({ element: container, initPosition, targetPosition });
 
       // Then
       const accumulatedGridSelection = store.getState().gridSelection.accumulated.dayGridMonth;

--- a/apps/calendar/src/hooks/gridSelection/useGridSelection.ts
+++ b/apps/calendar/src/hooks/gridSelection/useGridSelection.ts
@@ -65,11 +65,11 @@ export function useGridSelection<DateCollection>({
 
   const currentGridSelectionType = DRAGGING_TYPE_CREATORS.gridSelection(type);
 
-  const setGridSelectionByPosition = (e: MouseEvent, initGridPos: GridPosition) => {
+  const setGridSelectionByPosition = (e: MouseEvent) => {
     const gridPosition = gridPositionFinder(e);
 
-    if (isPresent(gridPosition)) {
-      setGridSelection(type, selectionSorter(initGridPos, gridPosition));
+    if (isPresent(initGridPosition) && isPresent(gridPosition)) {
+      setGridSelection(type, selectionSorter(initGridPosition, gridPosition));
     }
   };
 
@@ -109,18 +109,14 @@ export function useGridSelection<DateCollection>({
 
   const onMouseUp = (e: MouseEvent, isClickEvent: boolean) => {
     // The grid selection is created on mouseup in case of the click event.
-    if (isClickEvent && isPresent(initGridPosition)) {
-      setGridSelectionByPosition(e, initGridPosition);
+    if (isClickEvent) {
+      setGridSelectionByPosition(e);
     }
 
     if (isPresent(gridSelectionRef.current)) {
       const [startDate, endDate] = sortDates(
         ...dateGetter(dateCollection, gridSelectionRef.current)
       );
-
-      if (!useFormPopup) {
-        addGridSelection(type, gridSelectionRef.current);
-      }
 
       if (useFormPopup && isPresent(initMousePosition)) {
         const popupArrowPointPosition = {
@@ -170,16 +166,18 @@ export function useGridSelection<DateCollection>({
       if (isPresent(gridPosition)) {
         setInitGridPosition(gridPosition);
       }
+
+      if (!useFormPopup) {
+        addGridSelection(type, gridSelectionRef.current);
+      }
     },
     onDragStart: (e) => {
       // The grid selection is created on mousemove in case of the drag event.
-      if (isPresent(initGridPosition)) {
-        setGridSelectionByPosition(e, initGridPosition);
-      }
+      setGridSelectionByPosition(e);
     },
     onDrag: (e) => {
-      if (isSelectingGridRef.current && isPresent(initGridPosition)) {
-        setGridSelectionByPosition(e, initGridPosition);
+      if (isSelectingGridRef.current) {
+        setGridSelectionByPosition(e);
       }
     },
     onMouseUp: (e, { draggingState }) => {

--- a/apps/calendar/src/hooks/gridSelection/useGridSelection.ts
+++ b/apps/calendar/src/hooks/gridSelection/useGridSelection.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { useDispatch, useStore } from '@src/contexts/calendarStore';
 import { useEventBus } from '@src/contexts/eventBus';
+import { useLayoutContainer } from '@src/contexts/layoutContainer';
+import { cls } from '@src/helpers/css';
 import { DRAGGING_TYPE_CREATORS } from '@src/helpers/drag';
 import { useClickPrevention } from '@src/hooks/common/useClickPrevention';
 import { useDrag } from '@src/hooks/common/useDrag';
@@ -16,6 +18,12 @@ import type { GridSelectionData } from '@t/components/gridSelection';
 import type { GridPosition, GridPositionFinder } from '@t/grid';
 import type { Coordinates } from '@t/mouse';
 import type { CalendarState } from '@t/store';
+
+const GRID_SELECTION_TYPE_MAP = {
+  dayGridMonth: 'month',
+  dayGridWeek: 'allday',
+  timeGrid: 'time',
+};
 
 function sortDates(a: TZDate, b: TZDate) {
   const isIncreased = a < b;
@@ -45,6 +53,7 @@ export function useGridSelection<DateCollection>({
   const { setGridSelection, addGridSelection } = useDispatch('gridSelection');
   const { hideAllPopup, showFormPopup } = useDispatch('popup');
   const eventBus = useEventBus();
+  const layoutContainer = useLayoutContainer();
 
   const [initMousePosition, setInitMousePosition] = useState<Coordinates | null>(null);
   const [initGridPosition, setInitGridPosition] = useState<GridPosition | null>(null);
@@ -136,11 +145,18 @@ export function useGridSelection<DateCollection>({
         });
       }
 
+      const gridSelectionSelector = `.${cls(GRID_SELECTION_TYPE_MAP[type])}.${cls(
+        'grid-selection'
+      )}`;
+      const gridSelectionElements =
+        layoutContainer?.querySelectorAll(gridSelectionSelector) ?? ([] as unknown as NodeList);
+
       eventBus.fire('selectDateTime', {
         start: startDate.toDate(),
         end: endDate.toDate(),
         isAllday: type !== 'timeGrid',
         nativeEvent: e,
+        gridSelectionElements,
       });
     }
   };

--- a/apps/calendar/src/slices/gridSelection.ts
+++ b/apps/calendar/src/slices/gridSelection.ts
@@ -1,7 +1,5 @@
 import produce from 'immer';
 
-import { isFunction } from '@src/utils/type';
-
 import type { GridSelectionData } from '@t/components/gridSelection';
 import type { CalendarState, CalendarStore, SetState } from '@t/store';
 
@@ -19,13 +17,7 @@ export type GridSelectionSlice = {
 export type GridSelectionType = Exclude<keyof GridSelectionSlice['gridSelection'], 'accumulated'>;
 
 export type GridSelectionDispatchers = {
-  setGridSelection: (
-    type: GridSelectionType,
-    gridSelection:
-      | GridSelectionData
-      | null
-      | ((prev: GridSelectionData | null) => GridSelectionData | null)
-  ) => void;
+  setGridSelection: (type: GridSelectionType, gridSelection: GridSelectionData | null) => void;
   addGridSelection: (type: GridSelectionType, gridSelection: GridSelectionData | null) => void;
   clearAll: () => void;
 };
@@ -50,9 +42,7 @@ export function createGridSelectionDispatchers(
     setGridSelection: (type, gridSelection) => {
       set(
         produce((state: CalendarState) => {
-          state.gridSelection[type] = isFunction(gridSelection)
-            ? gridSelection(state.gridSelection[type])
-            : gridSelection;
+          state.gridSelection[type] = gridSelection;
         })
       );
     },

--- a/apps/calendar/src/types/eventBus.ts
+++ b/apps/calendar/src/types/eventBus.ts
@@ -7,6 +7,7 @@ export interface SelectDateTimeInfo {
   end: Date;
   isAllday: boolean;
   nativeEvent?: MouseEvent;
+  gridSelectionElements: NodeList;
 }
 
 export interface UpdatedEventInfo {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

- pass grid selection elements when `selectDateTime` custom event is fired
  - current grid selection is added on accumulated grid selections when drag start


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
