### PR TITLE
fix: avoid calling `rm -rf` to remove parent directory

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,17 +35,19 @@ jobs:
       - name: Switch branch
         run: |
           git switch gh-pages
+      - name: Remove previous docs
+        run: |
+          rm -rf latest
+          rm -rf ${{ steps.cpv.outputs.committed-version }}
       - name: Commit docs
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           git config --local user.email "dohyung.ahn@nhn.com"
           git config --local user.name "Dohyung Ahn"
-          rm -rf ../../latest
-          rm -rf ../../${{ steps.cpv.outputs.committed-version }}
           mv -i _latest ../../latest
           mv _${{ steps.cpv.outputs.committed-version }} ../../${{ steps.cpv.outputs.committed-version }}
           git add -A
           git commit -m ${{ steps.cpv.outputs.committed-version }}
-        working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Publish new docs
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

The current `publish-docs` action fails due to calling `rm -rf` inside the working directory. This PR addresses this problem.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
