### PR TITLE
fix: apply border-radius only on the first and last date of a horizontal event

### DIFF
--- a/apps/calendar/src/components/events/horizontalEvent.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.tsx
@@ -36,6 +36,13 @@ function getMargins(flat: boolean) {
   };
 }
 
+function getBorderRadius(exceedLeft: boolean, exceedRight: boolean): string {
+  const leftBorderRadius = exceedLeft ? 0 : '2px';
+  const rightBorderRadius = exceedRight ? 0 : '2px';
+
+  return `${leftBorderRadius} ${rightBorderRadius} ${rightBorderRadius} ${leftBorderRadius}`;
+}
+
 function getEventItemStyle({
   uiModel,
   flat,
@@ -56,7 +63,7 @@ function getEventItemStyle({
     color,
     backgroundColor: isDraggingTarget ? dragBackgroundColor : backgroundColor,
     borderLeft: exceedLeft ? 'none' : `3px solid ${borderColor}`,
-    borderRadius: exceedLeft ? 0 : 2,
+    borderRadius: getBorderRadius(exceedLeft, exceedRight),
     overflow: 'hidden',
     height: eventHeight,
     lineHeight: toPx(eventHeight),


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

- Apply `border-radius` only on the first and last date of a horizontal event.
![image](https://user-images.githubusercontent.com/8615506/177232567-289c857c-c39e-4334-8868-992a9389557f.png)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
