### PR TITLE
release: 2.0.2

### DIFF
--- a/.github/workflows/publish-calendar.yml
+++ b/.github/workflows/publish-calendar.yml
@@ -41,10 +41,10 @@ jobs:
           path: ${{ env.WORKING_DIRECTORY }}
       - name: Create new version tag
         run: |
-          git tag v${{ steps.cpv.outputs.committed-version }}
+          git tag calendar@${{ steps.cpv.outputs.committed-version }}
       - name: Push new version tag
         run: |
-          git push origin v${{ steps.cpv.outputs.committed-version }}
+          git push origin calendar@${{ steps.cpv.outputs.committed-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update the relative links in README

--- a/apps/calendar/package.json
+++ b/apps/calendar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toast-ui/calendar",
   "author": "NHN Cloud FE Development Lab <dl_javascript@nhn.com>",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "./dist/toastui-calendar.js",
   "types": "./types/index.d.ts",
   "sideEffects": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
     },
     "apps/calendar": {
       "name": "@toast-ui/calendar",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "immer": "^9.0.12",


### PR DESCRIPTION
- Release `calendar@2.0.2`
- Use new tag naming