### PR TITLE
fix: getWeekDates calculate week dates correctly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,7 +101,6 @@ module.exports = {
             assertFunctionNames: ['expect', 'assert*'],
           },
         ],
-        'require-await': 'off',
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
             assertFunctionNames: ['expect', 'assert*'],
           },
         ],
+        'require-await': 'off',
       },
     },
     {

--- a/apps/calendar/src/helpers/grid.spec.ts
+++ b/apps/calendar/src/helpers/grid.spec.ts
@@ -866,6 +866,7 @@ describe('createGridPositionFinder', () => {
 });
 
 describe('getWeekDates', () => {
+  // 2022-07-17(Sun) ~ 2022-07-23(Sat)
   const todayList = [
     new TZDate(2022, 6, 17),
     new TZDate(2022, 6, 18),
@@ -879,6 +880,7 @@ describe('getWeekDates', () => {
     jest.clearAllMocks();
   });
 
+  // startDayOfWeek, dayOfToday, prevDateCountOfToday, nextDateCountOfToday
   test.concurrent.each([
     [Day.SUN, Day.SUN, 0, 6],
     [Day.SUN, Day.MON, 1, 5],

--- a/apps/calendar/src/helpers/grid.spec.ts
+++ b/apps/calendar/src/helpers/grid.spec.ts
@@ -933,6 +933,7 @@ describe('getWeekDates', () => {
     [Day.SAT, Day.SAT, 0, 6],
   ])(
     'startDayOfWeek: %i, today: %i',
+    // eslint-disable-next-line require-await
     async (startDayOfWeek, dayOfToday, prevDateCount, nextDateCount) => {
       // Given
       const today = todayList[dayOfToday];

--- a/apps/calendar/src/helpers/grid.spec.ts
+++ b/apps/calendar/src/helpers/grid.spec.ts
@@ -864,3 +864,85 @@ describe('createGridPositionFinder', () => {
     );
   });
 });
+
+describe('getWeekDates', () => {
+  const todayList = [
+    new TZDate(2022, 6, 17),
+    new TZDate(2022, 6, 18),
+    new TZDate(2022, 6, 19),
+    new TZDate(2022, 6, 20),
+    new TZDate(2022, 6, 21),
+    new TZDate(2022, 6, 22),
+    new TZDate(2022, 6, 23),
+  ];
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.concurrent.each([
+    [Day.SUN, Day.SUN, 0, 6],
+    [Day.SUN, Day.MON, 1, 5],
+    [Day.SUN, Day.TUE, 2, 4],
+    [Day.SUN, Day.WED, 3, 3],
+    [Day.SUN, Day.THU, 4, 2],
+    [Day.SUN, Day.FRI, 5, 1],
+    [Day.SUN, Day.SAT, 6, 0],
+    [Day.MON, Day.SUN, 6, 0],
+    [Day.MON, Day.MON, 0, 6],
+    [Day.MON, Day.TUE, 1, 5],
+    [Day.MON, Day.WED, 2, 4],
+    [Day.MON, Day.THU, 3, 3],
+    [Day.MON, Day.FRI, 4, 2],
+    [Day.MON, Day.SAT, 5, 1],
+    [Day.TUE, Day.SUN, 5, 1],
+    [Day.TUE, Day.MON, 6, 0],
+    [Day.TUE, Day.TUE, 0, 6],
+    [Day.TUE, Day.WED, 1, 5],
+    [Day.TUE, Day.THU, 2, 4],
+    [Day.TUE, Day.FRI, 3, 3],
+    [Day.TUE, Day.SAT, 4, 2],
+    [Day.WED, Day.SUN, 4, 2],
+    [Day.WED, Day.MON, 5, 1],
+    [Day.WED, Day.TUE, 6, 0],
+    [Day.WED, Day.WED, 0, 6],
+    [Day.WED, Day.THU, 1, 5],
+    [Day.WED, Day.FRI, 2, 4],
+    [Day.WED, Day.SAT, 3, 3],
+    [Day.THU, Day.SUN, 3, 3],
+    [Day.THU, Day.MON, 4, 2],
+    [Day.THU, Day.TUE, 5, 1],
+    [Day.THU, Day.WED, 6, 0],
+    [Day.THU, Day.THU, 0, 6],
+    [Day.THU, Day.FRI, 1, 5],
+    [Day.THU, Day.SAT, 2, 4],
+    [Day.FRI, Day.SUN, 2, 4],
+    [Day.FRI, Day.MON, 3, 3],
+    [Day.FRI, Day.TUE, 4, 2],
+    [Day.FRI, Day.WED, 5, 1],
+    [Day.FRI, Day.THU, 6, 0],
+    [Day.FRI, Day.FRI, 0, 6],
+    [Day.FRI, Day.SAT, 1, 5],
+    [Day.SAT, Day.SUN, 1, 5],
+    [Day.SAT, Day.MON, 2, 4],
+    [Day.SAT, Day.TUE, 3, 3],
+    [Day.SAT, Day.WED, 4, 2],
+    [Day.SAT, Day.THU, 5, 1],
+    [Day.SAT, Day.FRI, 6, 0],
+    [Day.SAT, Day.SAT, 0, 6],
+  ])(
+    'startDayOfWeek: %i, today: %i',
+    async (startDayOfWeek, dayOfToday, prevDateCount, nextDateCount) => {
+      // Given
+      const today = todayList[dayOfToday];
+      const prevDateList = range(-prevDateCount, 0).map((step) => addDate(today, step));
+      const nextDateList = range(1, nextDateCount + 1).map((step) => addDate(today, step));
+      const expected = [...prevDateList, today, ...nextDateList];
+
+      // When
+      const dates = getWeekDates(today, { startDayOfWeek, workweek: false });
+
+      // Then
+      expect(dates).toEqual(expected);
+    }
+  );
+});

--- a/apps/calendar/src/helpers/grid.ts
+++ b/apps/calendar/src/helpers/grid.ts
@@ -351,13 +351,18 @@ export function getWeekDates(
   renderDate: TZDate,
   { startDayOfWeek = Day.SUN, workweek }: WeekOptions
 ): TZDate[] {
-  const renderDay = renderDate.getDay();
   const now = toStartOfDay(renderDate);
   const nowDay = now.getDay();
-  const prevWeekCount = startDayOfWeek - WEEK_DAYS;
+  const prevDateCount = nowDay - startDayOfWeek;
 
-  return range(startDayOfWeek, WEEK_DAYS + startDayOfWeek).reduce<TZDate[]>((acc, day) => {
-    const date = addDate(now, day - nowDay + (startDayOfWeek > renderDay ? prevWeekCount : 0));
+  const weekDayList =
+    prevDateCount >= 0
+      ? range(-prevDateCount, WEEK_DAYS - prevDateCount)
+      : range(-WEEK_DAYS - prevDateCount, -prevDateCount);
+
+  return weekDayList.reduce<TZDate[]>((acc, day) => {
+    const date = addDate(now, day);
+
     if (workweek && isWeekend(date.getDay())) {
       return acc;
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

- fixed calculation of `getWeekDates` correctly
- today: `Friday`, `startDayOfWeek`: `6(Saturday)`
  - AS-IS
![스크린샷 2022-07-15 오후 4 04 14](https://user-images.githubusercontent.com/28647773/179460340-e05db005-d6cb-48e3-9ec6-c10d3fd2fb39.png)
  - TO-BE
![스크린샷 2022-07-15 오후 4 03 40](https://user-images.githubusercontent.com/28647773/179460392-fab3c6d2-8479-411f-b504-00b0c5754893.png)


This issue resolves #1198.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
