### PR TITLE
fix: prevent firing `clickEvent` when dragging events (fix #1216)

### DIFF
--- a/apps/calendar/src/components/events/horizontalEvent.spec.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.spec.tsx
@@ -9,6 +9,71 @@ import { EventBusImpl } from '@src/utils/eventBus';
 
 import type { ExternalEventTypes } from '@t/eventBus';
 
+describe(`Firing 'clickEvent'`, () => {
+  const eventTitle = 'click-event';
+  function setup() {
+    const eventBus = new EventBusImpl<ExternalEventTypes>();
+    const handler = jest.fn();
+    eventBus.on('clickEvent', handler);
+    const uiModel = new EventUIModel(
+      new EventModel({
+        id: '1',
+        title: eventTitle,
+        start: new Date(2020, 0, 1, 10, 0),
+        end: new Date(2020, 0, 1, 12, 0),
+      })
+    );
+    const props = {
+      uiModel,
+      eventHeight: 30,
+      headerHeight: 0,
+    };
+
+    return {
+      props,
+      eventBus,
+      handler,
+    };
+  }
+
+  it('should fire event when clicked', () => {
+    // Given
+    const { props, eventBus, handler } = setup();
+    render(<HorizontalEvent {...props} />, { eventBus });
+
+    // When
+    const event = screen.getByText(eventTitle);
+    fireEvent.mouseDown(event);
+    fireEvent.mouseUp(event);
+
+    // Then
+    expect(handler).toBeCalledWith(
+      expect.objectContaining({
+        event: props.uiModel.model.toEventObject(),
+      })
+    );
+  });
+
+  it('should not fire when dragged', () => {
+    // Given
+    const { props, eventBus, handler } = setup();
+    render(<HorizontalEvent {...props} />, { eventBus });
+
+    // When
+    const event = screen.getByText(eventTitle);
+    dragAndDrop({
+      element: event,
+      targetPosition: {
+        clientX: 100,
+        clientY: 100,
+      },
+    });
+
+    // Then
+    expect(handler).not.toBeCalled();
+  });
+});
+
 describe(`Firing 'afterRenderEvent'`, () => {
   function setup() {
     const eventBus = new EventBusImpl<ExternalEventTypes>();

--- a/apps/calendar/src/components/events/horizontalEvent.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.tsx
@@ -202,7 +202,9 @@ export function HorizontalEvent({
         );
       }
 
-      eventBus.fire('clickEvent', { event: uiModel.model.toEventObject(), nativeEvent: e });
+      if (isClick) {
+        eventBus.fire('clickEvent', { event: uiModel.model.toEventObject(), nativeEvent: e });
+      }
     },
     onPressESCKey: () => endDragEvent(classNames.moveEvent),
   });

--- a/apps/calendar/src/components/events/timeEvent.spec.tsx
+++ b/apps/calendar/src/components/events/timeEvent.spec.tsx
@@ -10,6 +10,71 @@ import { EventBusImpl } from '@src/utils/eventBus';
 
 import type { ExternalEventTypes } from '@t/eventBus';
 
+describe(`Firing 'clickEvent'`, () => {
+  const eventTitle = 'click-event';
+
+  function setup() {
+    const eventBus = new EventBusImpl<ExternalEventTypes>();
+    const handler = jest.fn();
+    eventBus.on('clickEvent', handler);
+    const uiModel = new EventUIModel(
+      new EventModel({
+        id: '1',
+        title: eventTitle,
+        start: new Date('2022-05-19T09:00:00'),
+        end: new Date('2022-05-19T10:00:00'),
+      })
+    );
+    const props = {
+      uiModel,
+      nextStartTime: new TZDate('2022-05-19T11:00:00'),
+    };
+
+    return {
+      props,
+      eventBus,
+      handler,
+    };
+  }
+
+  it('should fire event when clicked', () => {
+    // Given
+    const { eventBus, handler, props } = setup();
+    render(<TimeEvent {...props} />, { eventBus });
+
+    // When
+    const event = screen.getByText(eventTitle);
+    fireEvent.mouseDown(event);
+    fireEvent.mouseUp(event);
+
+    // Then
+    expect(handler).toBeCalledWith(
+      expect.objectContaining({
+        event: props.uiModel.model.toEventObject(),
+      })
+    );
+  });
+
+  it('should not fire when dragged', () => {
+    // Given
+    const { eventBus, handler, props } = setup();
+    render(<TimeEvent {...props} />, { eventBus });
+
+    // When
+    const event = screen.getByText(eventTitle);
+    dragAndDrop({
+      element: event,
+      targetPosition: {
+        clientX: 100,
+        clientY: 100,
+      },
+    });
+
+    // Then
+    expect(handler).not.toBeCalled();
+  });
+});
+
 describe(`Firing 'afterRenderEvent'`, () => {
   function setup() {
     const eventBus = new EventBusImpl<ExternalEventTypes>();

--- a/apps/calendar/src/components/events/timeEvent.tsx
+++ b/apps/calendar/src/components/events/timeEvent.tsx
@@ -207,7 +207,9 @@ export function TimeEvent({
         );
       }
 
-      eventBus.fire('clickEvent', { event: uiModel.model.toEventObject(), nativeEvent: e });
+      if (isClick) {
+        eventBus.fire('clickEvent', { event: uiModel.model.toEventObject(), nativeEvent: e });
+      }
     },
     onPressESCKey: () => endDragEvent(classNames.moveEvent),
   });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

- This issue resolves #1216.
- The `clickEvent` event should be fired only when clicked.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
