### PR TITLE
fix: sync form state with inputs (fix #1233)

### DIFF
--- a/apps/calendar/src/components/popup/locationInputBox.tsx
+++ b/apps/calendar/src/components/popup/locationInputBox.tsx
@@ -1,11 +1,15 @@
 import { h } from 'preact';
+import type { ChangeEventHandler } from 'preact/compat';
 
 import { PopupSection } from '@src/components/popup/popupSection';
 import { cls } from '@src/helpers/css';
+import type { FormStateDispatcher } from '@src/hooks/popup/useFormState';
+import { FormStateActionType } from '@src/hooks/popup/useFormState';
 import { useStringOnlyTemplate } from '@src/hooks/template/useStringOnlyTemplate';
 
 interface Props {
-  location: string;
+  location?: string;
+  formStateDispatch: FormStateDispatcher;
 }
 
 const classNames = {
@@ -14,11 +18,15 @@ const classNames = {
   content: cls('content'),
 };
 
-export function LocationInputBox({ location }: Props) {
+export function LocationInputBox({ location, formStateDispatch }: Props) {
   const locationPlaceholder = useStringOnlyTemplate({
     template: 'locationPlaceholder',
     defaultValue: 'Location',
   });
+
+  const handleLocationChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    formStateDispatch({ type: FormStateActionType.setLocation, location: e.currentTarget.value });
+  };
 
   return (
     <PopupSection>
@@ -29,6 +37,7 @@ export function LocationInputBox({ location }: Props) {
           className={classNames.content}
           placeholder={locationPlaceholder}
           value={location}
+          onChange={handleLocationChange}
         />
       </div>
     </PopupSection>

--- a/apps/calendar/src/components/popup/titleInputBox.tsx
+++ b/apps/calendar/src/components/popup/titleInputBox.tsx
@@ -1,4 +1,5 @@
 import { h } from 'preact';
+import type { ChangeEventHandler } from 'preact/compat';
 
 import { PopupSection } from '@src/components/popup/popupSection';
 import { cls } from '@src/helpers/css';
@@ -7,7 +8,7 @@ import { FormStateActionType } from '@src/hooks/popup/useFormState';
 import { useStringOnlyTemplate } from '@src/hooks/template/useStringOnlyTemplate';
 
 interface Props {
-  title: string;
+  title?: string;
   isPrivate?: boolean;
   formStateDispatch: FormStateDispatcher;
 }
@@ -28,6 +29,10 @@ export function TitleInputBox({ title, isPrivate = false, formStateDispatch }: P
   const togglePrivate = () =>
     formStateDispatch({ type: FormStateActionType.setPrivate, isPrivate: !isPrivate });
 
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    formStateDispatch({ type: FormStateActionType.setTitle, title: e.currentTarget.value });
+  };
+
   return (
     <PopupSection>
       <div className={classNames.popupSectionItem}>
@@ -37,6 +42,7 @@ export function TitleInputBox({ title, isPrivate = false, formStateDispatch }: P
           className={classNames.content}
           placeholder={titlePlaceholder}
           value={title}
+          onChange={handleInputChange}
           required
         />
       </div>

--- a/apps/calendar/src/hooks/popup/useFormState.ts
+++ b/apps/calendar/src/hooks/popup/useFormState.ts
@@ -4,16 +4,22 @@ import type { EventObject, EventState } from '@t/events';
 
 export enum FormStateActionType {
   setCalendarId = 'setCalendarId',
+  setTitle = 'setTitle',
+  setLocation = 'setLocation',
   setPrivate = 'setPrivate',
   setAllday = 'setAllday',
   setState = 'setState',
+  reset = 'reset',
 }
 
 type FormStateAction =
   | { type: FormStateActionType.setCalendarId; calendarId: string }
+  | { type: FormStateActionType.setTitle; title: string }
+  | { type: FormStateActionType.setLocation; location: string }
   | { type: FormStateActionType.setPrivate; isPrivate: boolean }
   | { type: FormStateActionType.setAllday; isAllday: boolean }
-  | { type: FormStateActionType.setState; state: EventState };
+  | { type: FormStateActionType.setState; state: EventState }
+  | { type: FormStateActionType.reset; event: EventObject };
 
 export type FormStateDispatcher = (action: FormStateAction) => void;
 
@@ -21,18 +27,29 @@ function formStateReducer(state: EventObject, action: FormStateAction): EventObj
   switch (action.type) {
     case FormStateActionType.setCalendarId:
       return { ...state, calendarId: action.calendarId };
+    case FormStateActionType.setTitle:
+      return { ...state, title: action.title };
+    case FormStateActionType.setLocation:
+      return { ...state, location: action.location };
     case FormStateActionType.setPrivate:
       return { ...state, isPrivate: action.isPrivate };
     case FormStateActionType.setAllday:
       return { ...state, isAllday: action.isAllday };
     case FormStateActionType.setState:
       return { ...state, state: action.state };
+    case FormStateActionType.reset:
+      return { ...state, ...action.event };
 
     default:
       return state;
   }
 }
 
-export function useFormState(initialState: EventObject) {
+export function useFormState(
+  initialState: Pick<
+    EventObject,
+    'calendarId' | 'title' | 'location' | 'isPrivate' | 'isAllday' | 'state'
+  >
+) {
   return useReducer(formStateReducer, initialState);
 }

--- a/apps/calendar/src/hooks/popup/useFormState.ts
+++ b/apps/calendar/src/hooks/popup/useFormState.ts
@@ -3,6 +3,7 @@ import { useReducer } from 'preact/hooks';
 import type { EventObject, EventState } from '@t/events';
 
 export enum FormStateActionType {
+  init = 'init',
   setCalendarId = 'setCalendarId',
   setTitle = 'setTitle',
   setLocation = 'setLocation',
@@ -13,18 +14,30 @@ export enum FormStateActionType {
 }
 
 type FormStateAction =
+  | { type: FormStateActionType.init; event: EventObject }
   | { type: FormStateActionType.setCalendarId; calendarId: string }
   | { type: FormStateActionType.setTitle; title: string }
   | { type: FormStateActionType.setLocation; location: string }
   | { type: FormStateActionType.setPrivate; isPrivate: boolean }
   | { type: FormStateActionType.setAllday; isAllday: boolean }
   | { type: FormStateActionType.setState; state: EventState }
-  | { type: FormStateActionType.reset; event: EventObject };
+  | { type: FormStateActionType.reset };
 
 export type FormStateDispatcher = (action: FormStateAction) => void;
 
+const defaultFormState: EventObject = {
+  title: '',
+  location: '',
+  isAllday: false,
+  isPrivate: false,
+  state: 'Busy',
+};
+
+// eslint-disable-next-line complexity
 function formStateReducer(state: EventObject, action: FormStateAction): EventObject {
   switch (action.type) {
+    case FormStateActionType.init:
+      return { ...defaultFormState, ...action.event };
     case FormStateActionType.setCalendarId:
       return { ...state, calendarId: action.calendarId };
     case FormStateActionType.setTitle:
@@ -38,18 +51,13 @@ function formStateReducer(state: EventObject, action: FormStateAction): EventObj
     case FormStateActionType.setState:
       return { ...state, state: action.state };
     case FormStateActionType.reset:
-      return { ...state, ...action.event };
+      return { ...state, ...defaultFormState };
 
     default:
       return state;
   }
 }
 
-export function useFormState(
-  initialState: Pick<
-    EventObject,
-    'calendarId' | 'title' | 'location' | 'isPrivate' | 'isAllday' | 'state'
-  >
-) {
-  return useReducer(formStateReducer, initialState);
+export function useFormState(initCalendarId?: string) {
+  return useReducer(formStateReducer, { calendarId: initCalendarId, ...defaultFormState });
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

- Synced form state with input components
  - Some of `formState` was irrelevant to the popup. So it was removed.
- Reset form states when closing the popup

Resolves #1233 

#### As is

https://user-images.githubusercontent.com/14539203/182062782-71c66a43-82f3-4fd6-900c-69ab6085d9d3.mov



#### To be

https://user-images.githubusercontent.com/14539203/182062796-e43d890d-6bf3-46a6-8005-9c9390d69e06.mov


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
