### PR TITLE
fix: calculate endRowIndex properly when `week.hourStart/hourEnd` option is applied (fix #1238)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,6 +110,7 @@ module.exports = {
       files: ['apps/calendar/playwright/**/*.ts'],
       extends: ['plugin:playwright/playwright-test'],
       rules: {
+        'playwright/no-force-option': 'off',
         'max-nested-callbacks': ['error', { max: 5 }],
         'dot-notation': ['error', { allowKeywords: true }],
       },

--- a/apps/calendar/playwright/configs.ts
+++ b/apps/calendar/playwright/configs.ts
@@ -15,6 +15,10 @@ export const WEEK_VIEW_DUPLICATE_EVENTS_PAGE_URL = generatePageUrl(
   'e2e-week-view--duplicate-events'
 );
 
+export const WEEK_VIEW_HOUR_START_OPTION_PAGE_URL = generatePageUrl(
+  'e2e-week-view--hour-start-option'
+);
+
 export const MONTH_VIEW_EMPTY_PAGE_URL = generatePageUrl('e2e-month-view--empty');
 
 export const MONTH_VIEW_PAGE_URL = generatePageUrl('e2e-month-view--fixed-events');

--- a/apps/calendar/playwright/day/timeGridSelection.e2e.ts
+++ b/apps/calendar/playwright/day/timeGridSelection.e2e.ts
@@ -1,7 +1,6 @@
-import type { Locator } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 
-import type { FormattedTimeString } from '../../src/types/time/datetime';
+import { assertTimeGridSelection } from '../assertions';
 import { DAY_VIEW_PAGE_URL } from '../configs';
 import { ClickDelay } from '../constants';
 import {
@@ -16,30 +15,6 @@ test.beforeEach(async ({ page }) => {
 });
 
 const GRID_SELECTION_SELECTOR = '[data-testid*="time-grid-selection"]';
-
-async function assertTimeGridSelection(
-  selectionLocator: Locator,
-  expected: {
-    startTop: number;
-    endBottom: number;
-    formattedTimes: FormattedTimeString[];
-  }
-) {
-  await waitForSingleElement(selectionLocator);
-
-  const expectedFormattedTime = expected.formattedTimes.join(' - ');
-
-  await expect(selectionLocator.first()).toHaveText(expectedFormattedTime);
-
-  const firstElementBoundingBox = await getBoundingBox(selectionLocator.first());
-  expect(firstElementBoundingBox.y).toBeCloseTo(expected.startTop, 0);
-
-  const lastElementBoundingBox = await getBoundingBox(selectionLocator.last());
-  expect(lastElementBoundingBox.y + lastElementBoundingBox.height).toBeCloseTo(
-    expected.endBottom,
-    0
-  );
-}
 
 // NOTE: Only firefox automatically scrolls into view at some random tests, so narrowing the range of movement.
 // Maybe `scrollIntoViewIfNeeded` is not supported in the firefox?

--- a/apps/calendar/playwright/week/timeGridSelection.e2e.ts
+++ b/apps/calendar/playwright/week/timeGridSelection.e2e.ts
@@ -1,334 +1,394 @@
-import type { Locator } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 
-import type { FormattedTimeString } from '../../src/types/time/datetime';
-import { WEEK_VIEW_PAGE_URL } from '../configs';
+import { assertTimeGridSelection } from '../assertions';
+import { WEEK_VIEW_HOUR_START_OPTION_PAGE_URL, WEEK_VIEW_PAGE_URL } from '../configs';
 import { ClickDelay } from '../constants';
 import { dragAndDrop, getBoundingBox, getTimeGridLineSelector } from '../utils';
 
-test.beforeEach(async ({ page }) => {
-  await page.goto(WEEK_VIEW_PAGE_URL);
-});
-
-async function assertTimeGridSelection(
-  selectionLocator: Locator,
-  expected: {
-    startTop: number;
-    endBottom: number;
-    totalElements: number;
-    formattedTimes: FormattedTimeString[];
-  }
-) {
-  const timeGridSelectionElements = (await selectionLocator.evaluateAll(
-    (selection) => selection
-  )) as HTMLElement[];
-  const expectedFormattedTime = expected.formattedTimes.join(' - ');
-
-  expect(timeGridSelectionElements).toHaveLength(expected.totalElements);
-
-  await expect(selectionLocator.first()).toHaveText(expectedFormattedTime);
-
-  const firstElementBoundingBox = await getBoundingBox(selectionLocator.first());
-  expect(firstElementBoundingBox.y).toBeCloseTo(expected.startTop, 0);
-
-  const lastElementBoundingBox = await getBoundingBox(selectionLocator.last());
-  expect(lastElementBoundingBox.y + lastElementBoundingBox.height).toBeCloseTo(
-    expected.endBottom,
-    0
-  );
-}
-
-// NOTE: Only firefox automatically scrolls into view at some random tests, so narrowing the range of movement.
-// Maybe `scrollIntoViewIfNeeded` is not supported in the firefox?
-// reference: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded
-const BASE_GRIDLINE_SELECTOR = 'data-testid=gridline-03:00-03:30';
 const GRID_SELECTION_SELECTOR = '[data-testid*="time-grid-selection"]';
 
-test('should be able to select a time slot with clicking', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-
-  // When
-  await startGridLineLocator.click({ force: true, delay: ClickDelay.Short });
-  await timeGridSelectionLocator.waitFor(); // Test for debounced click handler.
-
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 1,
-    formattedTimes: ['03:00', '03:30'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
-  });
-});
-
-// FIXME: it fails on safari & firefox
-test.fixme('should be able to select a time slot with double clicking', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-
-  // When
-  await startGridLineLocator.dblclick({ force: true, delay: ClickDelay.Immediate });
-
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 1,
-    formattedTimes: ['03:00', '03:30'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
-  });
-});
-
-test('should be able to select a range of time from bottom to top', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('01:00'));
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
-
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-  const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
+test.describe('Time Grid Selection - Default Options', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(WEEK_VIEW_PAGE_URL);
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 1,
-    formattedTimes: ['01:00', '03:30'],
-    startTop: targetGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+  // NOTE: Only firefox automatically scrolls into view at some random tests, so narrowing the range of movement.
+  // Maybe `scrollIntoViewIfNeeded` is not supported in the firefox?
+  // reference: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded
+  const BASE_GRIDLINE_SELECTOR = 'data-testid=gridline-03:00-03:30';
+
+  test('should be able to select a time slot with clicking', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+
+    // When
+    await startGridLineLocator.click({ force: true, delay: ClickDelay.Short });
+    await timeGridSelectionLocator.waitFor(); // Test for debounced click handler.
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 1,
+      formattedTimes: ['03:00', '03:30'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
   });
-});
 
-test('should be able to select a range of time to upper right', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('01:00'));
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+  // FIXME: it fails on safari & firefox
+  test.fixme('should be able to select a time slot with double clicking', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
 
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-  const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+    // When
+    await startGridLineLocator.dblclick({ force: true, delay: ClickDelay.Immediate });
 
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
-    options: {
-      targetPosition: {
-        x: targetGridLineBoundingBox.width,
-        y: startGridLineBoundingBox.height,
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 1,
+      formattedTimes: ['03:00', '03:30'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
+  });
+
+  test('should be able to select a range of time from bottom to top', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('01:00'));
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 1,
+      formattedTimes: ['01:00', '03:30'],
+      startTop: targetGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
+  });
+
+  test('should be able to select a range of time to upper right', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('01:00'));
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      options: {
+        targetPosition: {
+          x: targetGridLineBoundingBox.width,
+          y: startGridLineBoundingBox.height,
+        },
       },
-    },
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 4,
+      formattedTimes: ['03:00'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
+    });
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 4,
-    formattedTimes: ['03:00'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
-  });
-});
+  test('should be able to select a range of time to right', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
 
-test('should be able to select a range of time to right', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
 
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: startGridLineLocator,
-    options: {
-      targetPosition: {
-        x: startGridLineBoundingBox.width,
-        y: 1,
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: startGridLineLocator,
+      options: {
+        targetPosition: {
+          x: startGridLineBoundingBox.width,
+          y: 1,
+        },
       },
-    },
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 4,
+      formattedTimes: ['03:00'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 4,
-    formattedTimes: ['03:00'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
-  });
-});
+  test('should be able to select a range of time to lower right', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
 
-test('should be able to select a range of time to lower right', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
 
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-  const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
-    options: {
-      targetPosition: {
-        x: targetGridLineBoundingBox.width,
-        y: targetGridLineBoundingBox.height,
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      options: {
+        targetPosition: {
+          x: targetGridLineBoundingBox.width,
+          y: targetGridLineBoundingBox.height,
+        },
       },
-    },
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 4,
+      formattedTimes: ['03:00'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
+    });
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 4,
-    formattedTimes: ['03:00'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
+  test('should be able to select a range of time from top to bottom', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 1,
+      formattedTimes: ['03:00', '05:30'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
+    });
   });
-});
 
-test('should be able to select a range of time from top to bottom', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+  test('should be able to select a range of time to lower left', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
 
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-  const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
 
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
-  });
-
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 1,
-    formattedTimes: ['03:00', '05:30'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
-  });
-});
-
-test('should be able to select a range of time to lower left', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
-
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-  const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
-    options: {
-      targetPosition: {
-        x: 0,
-        y: targetGridLineBoundingBox.height,
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      options: {
+        targetPosition: {
+          x: 0,
+          y: targetGridLineBoundingBox.height,
+        },
       },
-    },
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 4,
+      formattedTimes: ['05:00'],
+      startTop: targetGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 4,
-    formattedTimes: ['05:00'],
-    startTop: targetGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
-  });
-});
+  test('should be able to select a range of time to left', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
 
-test('should be able to select a range of time to left', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
 
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: startGridLineLocator,
-    options: {
-      targetPosition: {
-        x: 1,
-        y: 1,
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: startGridLineLocator,
+      options: {
+        targetPosition: {
+          x: 1,
+          y: 1,
+        },
       },
-    },
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 4,
+      formattedTimes: ['03:00'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 4,
-    formattedTimes: ['03:00'],
-    startTop: startGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
-  });
-});
+  test('should be able to select a range of time to upper left', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('01:00'));
+    const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
 
-test('should be able to select a range of time to upper left', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(BASE_GRIDLINE_SELECTOR);
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('01:00'));
-  const timeGridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
 
-  const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
-  const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
-    options: {
-      targetPosition: {
-        x: 1,
-        y: 1,
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      options: {
+        targetPosition: {
+          x: 1,
+          y: 1,
+        },
       },
-    },
+    });
+
+    // Then
+    await assertTimeGridSelection(timeGridSelectionLocator, {
+      totalElements: 4,
+      formattedTimes: ['01:00'],
+      startTop: targetGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
   });
 
-  // Then
-  await assertTimeGridSelection(timeGridSelectionLocator, {
-    totalElements: 4,
-    formattedTimes: ['01:00'],
-    startTop: targetGridLineBoundingBox.y,
-    endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+  test('When pressing down the ESC key, the grid selection is canceled.', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(getTimeGridLineSelector('03:00'));
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
+
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      hold: true,
+    });
+    await page.keyboard.down('Escape');
+
+    // Then
+    const gridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
+    expect(await gridSelectionLocator.count()).toBe(0);
   });
 });
 
-test('When pressing down the ESC key, the grid selection is canceled.', async ({ page }) => {
-  // Given
-  const startGridLineLocator = page.locator(getTimeGridLineSelector('03:00'));
-  const targetGridLineLocator = page.locator(getTimeGridLineSelector('05:00'));
-
-  // When
-  await dragAndDrop({
-    page,
-    sourceLocator: startGridLineLocator,
-    targetLocator: targetGridLineLocator,
-    hold: true,
+// Regression test for #1238
+// Since the most of the test duplicated with the normal one, check for a few cases including horizontal selections only.
+test.describe('Time Grid Selection - With different hourStart and hourEnd', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(WEEK_VIEW_HOUR_START_OPTION_PAGE_URL);
   });
-  await page.keyboard.down('Escape');
 
-  // Then
-  const gridSelectionLocator = page.locator(GRID_SELECTION_SELECTOR);
-  expect(await gridSelectionLocator.count()).toBe(0);
+  const getColumnSelector = (columnIndex: number) => `data-testid=timegrid-column-${columnIndex}`;
+
+  test('should be able to select a range of time to lower right', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(getTimeGridLineSelector('06:00'));
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('08:00'));
+    const startColumnLocator = page.locator(getColumnSelector(4));
+    const targetColumnLocator = page.locator(getColumnSelector(5));
+
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+    const startColumnBoundingBox = await getBoundingBox(startColumnLocator);
+    const endColumnBoundingBox = await getBoundingBox(targetColumnLocator);
+
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      options: {
+        sourcePosition: {
+          x: startColumnBoundingBox.x,
+          y: 5,
+        },
+        targetPosition: {
+          x: endColumnBoundingBox.x,
+          y: 5,
+        },
+      },
+    });
+
+    // Then
+    await assertTimeGridSelection(page.locator(GRID_SELECTION_SELECTOR), {
+      totalElements: 2,
+      formattedTimes: ['06:00'],
+      startTop: startGridLineBoundingBox.y,
+      endBottom: targetGridLineBoundingBox.y + targetGridLineBoundingBox.height,
+    });
+  });
+
+  test('should be able to select a range of time to upper left', async ({ page }) => {
+    // Given
+    const startGridLineLocator = page.locator(getTimeGridLineSelector('08:00'));
+    const targetGridLineLocator = page.locator(getTimeGridLineSelector('06:00'));
+    const startColumnLocator = page.locator(getColumnSelector(5));
+    const targetColumnLocator = page.locator(getColumnSelector(4));
+
+    const startGridLineBoundingBox = await getBoundingBox(startGridLineLocator);
+    const targetGridLineBoundingBox = await getBoundingBox(targetGridLineLocator);
+    const startColumnBoundingBox = await getBoundingBox(startColumnLocator);
+    const endColumnBoundingBox = await getBoundingBox(targetColumnLocator);
+
+    // When
+    await dragAndDrop({
+      page,
+      sourceLocator: startGridLineLocator,
+      targetLocator: targetGridLineLocator,
+      options: {
+        sourcePosition: {
+          x: startColumnBoundingBox.x,
+          y: 5,
+        },
+        targetPosition: {
+          x: endColumnBoundingBox.x,
+          y: 5,
+        },
+      },
+    });
+
+    // Then
+    await assertTimeGridSelection(page.locator(GRID_SELECTION_SELECTOR), {
+      totalElements: 2,
+      formattedTimes: ['06:00'],
+      startTop: targetGridLineBoundingBox.y,
+      endBottom: startGridLineBoundingBox.y + startGridLineBoundingBox.height,
+    });
+  });
 });

--- a/apps/calendar/src/components/timeGrid/gridSelectionByColumn.tsx
+++ b/apps/calendar/src/components/timeGrid/gridSelectionByColumn.tsx
@@ -47,8 +47,12 @@ export function GridSelectionByColumn({ columnIndex, timeGridRows }: Props) {
   const gridSelectionData = useStore(
     useCallback(
       (state: CalendarState) =>
-        timeGridSelectionHelper.calculateSelection(state.gridSelection.timeGrid, columnIndex),
-      [columnIndex]
+        timeGridSelectionHelper.calculateSelection(
+          state.gridSelection.timeGrid,
+          columnIndex,
+          timeGridRows.length - 1
+        ),
+      [columnIndex, timeGridRows]
     )
   );
 

--- a/apps/calendar/src/helpers/gridSelection.ts
+++ b/apps/calendar/src/helpers/gridSelection.ts
@@ -41,7 +41,8 @@ function createSortedGridSelection(
 
 function calculateTimeGridSelectionByCurrentIndex(
   timeGridSelection: GridSelectionData | null,
-  columnIndex: number
+  columnIndex: number,
+  maxRowIndex: number // maxRowIndex is the last row index of the `timeGridData.row`
 ) {
   if (isNil(timeGridSelection)) {
     return null;
@@ -64,10 +65,10 @@ function calculateTimeGridSelectionByCurrentIndex(
 
   if (startColumnIndex < columnIndex && columnIndex < endColumnIndex) {
     resultGridSelection.startRowIndex = 0;
-    resultGridSelection.endRowIndex = 47;
+    resultGridSelection.endRowIndex = maxRowIndex;
   } else if (startColumnIndex !== endColumnIndex) {
     if (startColumnIndex === columnIndex) {
-      resultGridSelection.endRowIndex = 47;
+      resultGridSelection.endRowIndex = maxRowIndex;
     } else if (endColumnIndex === columnIndex) {
       resultGridSelection.startRowIndex = 0;
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

This PR resolves #1238 and #1239.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
