### PR TITLE
fix: afterRenderEvent doesn't work in readonly mode ( fix #1327 )

### DIFF
--- a/apps/calendar/src/components/events/horizontalEvent.spec.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.spec.tsx
@@ -141,6 +141,31 @@ describe(`Firing 'afterRenderEvent'`, () => {
     // Then
     expect(handler).not.toBeCalled();
   });
+
+  it(`should fire 'afterRenderEvent' when it is in readonly mode`, () => {
+    // Given
+    const { eventBus, handler } = setup();
+    const uiModel = new EventUIModel(
+      new EventModel({
+        id: '1',
+        start: new Date(2020, 0, 1, 10, 0),
+        end: new Date(2020, 0, 1, 12, 0),
+        isReadOnly: true,
+      })
+    );
+
+    const props = {
+      uiModel,
+      eventHeight: 30,
+      headerHeight: 0,
+    };
+
+    // When
+    render(<HorizontalEvent {...props} />, { eventBus });
+
+    // Then
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('Apply customStyle', () => {
@@ -365,19 +390,5 @@ describe('isReadOnly', () => {
     fireEvent.mouseUp(event);
 
     expect(showDetailPopupSpy).toHaveBeenCalled();
-  });
-
-  it(`should fire 'afterRenderEvent' when it is in readonly mode`, () => {
-    // Given
-    const eventBus = new EventBusImpl<ExternalEventTypes>();
-    const handler = jest.fn();
-    eventBus.on('afterRenderEvent', handler);
-    const { props } = setup();
-
-    // When (resizingWidth)
-    render(<HorizontalEvent {...props} />, { eventBus });
-
-    // Then
-    expect(handler).toBeCalled();
   });
 });

--- a/apps/calendar/src/components/events/horizontalEvent.spec.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.spec.tsx
@@ -307,11 +307,7 @@ describe('Color values', () => {
 });
 
 describe('isReadOnly', () => {
-  it("should be able to show detail popup even if the model's `isReadOnly` property is `true`", () => {
-    // Given
-    const store = initCalendarStore({
-      useDetailPopup: true,
-    });
+  function setup() {
     const eventName = 'readonly-event';
     const uiModel = new EventUIModel(
       new EventModel({
@@ -322,6 +318,35 @@ describe('isReadOnly', () => {
         isReadOnly: true,
       })
     );
+
+    const props = {
+      uiModel,
+      eventHeight: 30,
+      headerHeight: 0,
+    };
+
+    return {
+      props,
+    };
+  }
+
+  it("should be able to show detail popup even if the model's `isReadOnly` property is `true`", () => {
+    // Given
+    const store = initCalendarStore({
+      useDetailPopup: true,
+    });
+
+    const eventName = 'readonly-event';
+    const uiModel = new EventUIModel(
+      new EventModel({
+        id: '1',
+        title: eventName,
+        start: new Date(2020, 0, 1, 10, 0),
+        end: new Date(2020, 0, 1, 12, 0),
+        isReadOnly: true,
+      })
+    );
+
     const props = {
       uiModel,
       eventHeight: 30,
@@ -340,5 +365,19 @@ describe('isReadOnly', () => {
     fireEvent.mouseUp(event);
 
     expect(showDetailPopupSpy).toHaveBeenCalled();
+  });
+
+  it(`should fire 'afterRenderEvent' when it is in readonly mode`, () => {
+    // Given
+    const eventBus = new EventBusImpl<ExternalEventTypes>();
+    const handler = jest.fn();
+    eventBus.on('afterRenderEvent', handler);
+    const { props } = setup();
+
+    // When (resizingWidth)
+    render(<HorizontalEvent {...props} />, { eventBus });
+
+    // Then
+    expect(handler).toBeCalled();
   });
 });

--- a/apps/calendar/src/components/events/horizontalEvent.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.tsx
@@ -170,7 +170,7 @@ export function HorizontalEvent({
   });
 
   useEffect(() => {
-    if (isDraggableEvent) {
+    if (isNil(resizingWidth) && isNil(movingLeft)) {
       eventBus.fire('afterRenderEvent', uiModel.model.toEventObject());
     }
     // This effect is only for the first render.

--- a/apps/calendar/src/components/events/horizontalEvent.tsx
+++ b/apps/calendar/src/components/events/horizontalEvent.tsx
@@ -16,7 +16,7 @@ import { dndSelector, optionsSelector, viewSelector } from '@src/selectors';
 import { DraggingState } from '@src/slices/dnd';
 import { isSameDate } from '@src/time/datetime';
 import { passConditionalProp } from '@src/utils/preact';
-import { isNil } from '@src/utils/type';
+import { isPresent } from '@src/utils/type';
 
 import type { CalendarColor } from '@t/options';
 
@@ -144,8 +144,9 @@ export function HorizontalEvent({
   const eventContainerRef = useRef<HTMLDivElement>(null);
 
   const { isReadOnly, id, calendarId } = uiModel.model;
-  const isDraggableEvent =
-    !isReadOnlyCalendar && !isReadOnly && isNil(resizingWidth) && isNil(movingLeft);
+
+  const isDraggingGuideEvent = isPresent(resizingWidth) || isPresent(movingLeft);
+  const isDraggableEvent = !isReadOnlyCalendar && !isReadOnly && !isDraggingGuideEvent;
 
   const startDragEvent = (className: string) => {
     setDraggingEventUIModel(uiModel);
@@ -160,8 +161,7 @@ export function HorizontalEvent({
     if (
       draggingState === DraggingState.DRAGGING &&
       draggingEventUIModel?.cid() === uiModel.cid() &&
-      isNil(resizingWidth) &&
-      isNil(movingLeft)
+      !isDraggingGuideEvent
     ) {
       setIsDraggingTarget(true);
     } else {
@@ -170,7 +170,7 @@ export function HorizontalEvent({
   });
 
   useEffect(() => {
-    if (isNil(resizingWidth) && isNil(movingLeft)) {
+    if (!isDraggingGuideEvent) {
       eventBus.fire('afterRenderEvent', uiModel.model.toEventObject());
     }
     // This effect is only for the first render.


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
 - afterRenderEvent works in readonly mode
 - add test in this feature 

Resolves #1327 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
