### PR TITLE
fix setCalendars() documentation typo both languages (fix #1393)

### DIFF
--- a/docs/en/apis/calendar.md
+++ b/docs/en/apis/calendar.md
@@ -498,11 +498,11 @@ Returns the view type currently displayed by the calendar instance.
 
 ```ts
 interface CalendarInfo {
-  id: string;
-  name: string;
-  color?: string;
-  bgColor?: string;
-  dragBgColor?: string;
+  id: string; 
+  name: string; 
+  color?: string; 
+  backgroundColor?: string; 
+  dragBackgroundColor?: string; 
   borderColor?: string;
 }
 ```

--- a/docs/ko/apis/calendar.md
+++ b/docs/ko/apis/calendar.md
@@ -503,11 +503,11 @@ calendar.setOptions({
 
 ```ts
 interface CalendarInfo {
-  id: string;
-  name: string;
-  color?: string;
-  bgColor?: string;
-  dragBgColor?: string;
+  id: string; 
+  name: string; 
+  color?: string; 
+  backgroundColor?: string; 
+  dragBackgroundColor?: string; 
   borderColor?: string;
 }
 ```


### PR DESCRIPTION
fix setCalendars() documentation typo both languages (fix #1393 )