### PR TITLE
fix: unselect grid selection before init (fix: #1300)

### DIFF
--- a/apps/calendar/src/hooks/gridSelection/useGridSelection.ts
+++ b/apps/calendar/src/hooks/gridSelection/useGridSelection.ts
@@ -182,6 +182,7 @@ export function useGridSelection<DateCollection>({
       const gridPosition = gridPositionFinder(e);
 
       if (isPresent(gridPosition)) {
+        clearAll();
         setInitGridPosition(gridPosition);
       }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

Clear a grid selection that was created before the coordinates of the grid selection were initialized.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
