### PR TITLE
fix: add `types` to indicate correct types path

### DIFF
--- a/apps/react-calendar/package.json
+++ b/apps/react-calendar/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "import": "./dist/toastui-react-calendar.mjs",
-      "require": "./dist/toastui-react-calendar.js"
+      "require": "./dist/toastui-react-calendar.js",
+      "types": "./types/index.d.ts"
     },
     "./ie11": "./dist/toastui-react-calendar.ie11.js",
     "./esm": "./dist/toastui-react-calendar.mjs"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
When setting up a brand new React project with TypeScript, I was getting this error:
```
Could not find a declaration file for module '@toast-ui/react-calendar'. '.../test-react-calendar/node_modules/@toast-ui/react-calendar/dist/toastui-react-calendar.mjs' implicitly has an 'any' type.
  There are types at '.../test-react-calendar/node_modules/@toast-ui/react-calendar/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@toast-ui/react-calendar' library may need to update its package.json or typings.ts(7016)
```

Which means that you have to include the path to the types file in `package.json`'s `export` config.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
