### PR TITLE
resolve type import issue with specific tsconfig settings

### DIFF
--- a/apps/calendar/package.json
+++ b/apps/calendar/package.json
@@ -11,7 +11,10 @@
   "exports": {
     ".": {
       "import": "./dist/toastui-calendar.mjs",
-      "require": "./dist/toastui-calendar.js"
+      "require": "./dist/toastui-calendar.js",
+       "types": {
+        "default": "./types/index.d.ts"
+       }
     },
     "./ie11": "./dist/toastui-calendar.ie11.js",
     "./esm": "./dist/toastui-calendar.mjs",

--- a/apps/react-calendar/package.json
+++ b/apps/react-calendar/package.json
@@ -17,7 +17,10 @@
   "exports": {
     ".": {
       "import": "./dist/toastui-react-calendar.mjs",
-      "require": "./dist/toastui-react-calendar.js"
+      "require": "./dist/toastui-react-calendar.js",
+      "types": {
+        "default": "./types/index.d.ts"
+      }
     },
     "./ie11": "./dist/toastui-react-calendar.ie11.js",
     "./esm": "./dist/toastui-react-calendar.mjs"


### PR DESCRIPTION
**fix: resolve type import issue with specific tsconfig settings**

### Please check if the PR fulfills these requirements

- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

In my project, I encountered an issue where the type files from `@toast-ui/react-calendar` could not be imported correctly. This was due to the `tsconfig` settings in my project, specifically using `"module": "esnext"` and `"moduleResolution": "bundler"`.

To resolve this issue, I updated the `package.json` of the `@toast-ui/react-calendar` project to ensure that the type files are correctly resolved and imported.

---

Thank you for your contribution to TOAST UI product. 🎉 😘 ✨